### PR TITLE
feat(Renderer): Support closures

### DIFF
--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -67,7 +67,7 @@ final class Renderer {
         return '';
       } else if ($node[0] === '$') {
         $type = $this->getNodeType($node);
-        assert(is_string($type) || $type instanceof \Closure, "Type must be a string or callable");
+        assert(is_string($type) || $type instanceof \Closure, "Type must be a string or closure.");
 
         $props = $this->getNodeProps($node);
 

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -55,11 +55,10 @@ final class Renderer {
         assert(is_string($type) || $type instanceof \Closure, "Type must be a string or callable");
 
         $props = $this->getNodeProps($node);
+
+        $hasChildren = array_key_exists(3, $node) || array_key_exists('children', $props);
         $children = $this->getNodeChildren($node);
-        $mergedProps = array_merge(
-          $props ?? [],
-          ($children ?? null) ? ['children' => $children] : []
-        );
+        $mergedProps = array_merge($props ?? [], $hasChildren ? ['children' => $children] : []);
 
         if (!is_string($type) && $type instanceof \Closure) {
           $id = spl_object_id($type);

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -53,6 +53,17 @@ final class Renderer {
     return $html;
   }
 
+  private function callComponent(\Closure|callable $component, array $props): mixed {
+    if ($component instanceof \Closure) {
+      $arity = $this->arityCache[$component] ?? ($this->arityCache[$component] = (new \ReflectionFunction($component))->getNumberOfParameters());
+      if ($arity > 1) {
+        throw new \InvalidArgumentException("Component must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
+      }
+      return $arity === 0 ? $component() : $component($props);
+    }
+    return call_user_func($component, $props);
+  }
+
   protected function format(string $rendered, int $nesting): string {
     return str_repeat($this->indentation, max(0, $nesting)).$rendered;
   }
@@ -75,26 +86,11 @@ final class Renderer {
         $props = array_merge($nodeProps, $childrenProps);
 
         if (!is_string($type) && $type instanceof \Closure) {
-          $arity = $this->arityCache[$type] ?? ($this->arityCache[$type] = (new \ReflectionFunction($type))->getNumberOfParameters());
-          if ($arity > 1) {
-            throw new \InvalidArgumentException("Component closure must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
-          }
-          $result = $arity === 0 ? $type() : $type($props);
-          return $this->renderNode($result, $nesting);
+          return $this->renderNode($this->callComponent($type, $props), $nesting);
         }
 
         if (array_key_exists($type, $this->components)) {
-          $component = $this->components[$type];
-          if ($component instanceof \Closure) {
-            $arity = $this->arityCache[$component] ?? ($this->arityCache[$component] = (new \ReflectionFunction($component))->getNumberOfParameters());
-            if ($arity > 1) {
-              throw new \InvalidArgumentException("Component '{$type}' must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
-            }
-            $result = $arity === 0 ? $component() : $component($props);
-          } else {
-            $result = call_user_func($component, $props);
-          }
-          return $this->renderNode($result, $nesting);
+          return $this->renderNode($this->callComponent($this->components[$type], $props), $nesting);
         }
 
         $shouldEscapeHtml = true;

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -56,12 +56,12 @@ final class Renderer {
 
         $props = $this->getNodeProps($node);
         $children = $this->getNodeChildren($node);
+        $mergedProps = array_merge(
+          $props ?? [],
+          ($children ?? null) ? ['children' => $children] : []
+        );
 
         if (!is_string($type) && $type instanceof \Closure) {
-          $mergedProps = array_merge(
-            $props ?? [],
-            ($children ?? null) ? ['children' => $children] : []
-          );
           $id = spl_object_id($type);
           $arity = $this->arityCache[$id] ?? ($this->arityCache[$id] = (new \ReflectionFunction($type))->getNumberOfParameters());
           $result = $arity === 0 ? $type() : $type($mergedProps);
@@ -69,14 +69,7 @@ final class Renderer {
         }
 
         if (array_key_exists($type, $this->components)) {
-          return $this->renderNode(
-            call_user_func(
-              $this->components[$type],
-              array_merge(
-                $props ?? [],
-                ($children ?? null) ? ['children' => $children] : []
-              )
-            ), $nesting);
+          return $this->renderNode(call_user_func($this->components[$type], $mergedProps), $nesting);
         }
 
         $shouldEscapeHtml = true;

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -200,7 +200,7 @@ final class Renderer {
           return "<$type".(empty($attributeString) ? '' : ' ' . $attributeString).">{$childrenRendered}</$type>";
         }
       } else {
-        $children = self::concatenateStringMembers($node, $this->react);
+        $children = self::concatenateStringMembers($node, $this->react, $this->encoding);
 
         $childrenRendered = [];
 
@@ -223,7 +223,7 @@ final class Renderer {
               throw new \Exception("Unexpected unflattened array in children");
             }
           } else if (is_string($child) || is_numeric($child)) {
-            $childrenRendered[] = $this->renderNode($child, $nesting + 1);
+            $childrenRendered[] = (string) $child;
             $previousChildWasElement = false;
           }
         }
@@ -235,7 +235,7 @@ final class Renderer {
     }
   }
 
-  protected static function concatenateStringMembers(array $array, bool $react): array {
+  protected static function concatenateStringMembers(array $array, bool $react, string $encoding = 'UTF-8'): array {
     $combinedArray = [];
     $currentString = '';
 
@@ -245,6 +245,7 @@ final class Renderer {
       if (
         is_string($item) || is_numeric($item)
       ) {
+        $escapedValue = htmlspecialchars((string) $item, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $encoding);
         if ($react) {
           $isFirst = $index === 0;
           $isLast = $index === $length - 1;
@@ -254,16 +255,16 @@ final class Renderer {
           $canBeTrimmedFromEnd = !$isLast && rtrim($stringifiedValue) !== $stringifiedValue;
 
           if ($canBeTrimmedFromStart && $canBeTrimmedFromEnd) {
-            $currentString .= '<!-- -->' . $stringifiedValue . '<!-- -->';
+            $currentString .= '<!-- -->' . $escapedValue . '<!-- -->';
           } else if ($canBeTrimmedFromEnd) {
-            $currentString .= $stringifiedValue . '<!-- -->';
+            $currentString .= $escapedValue . '<!-- -->';
           } else if ($canBeTrimmedFromStart) {
-            $currentString .= '<!-- -->' . $stringifiedValue;
+            $currentString .= '<!-- -->' . $escapedValue;
           } else {
-            $currentString .= $stringifiedValue;
+            $currentString .= $escapedValue;
           }
         } else {
-          $currentString .= (string) $item;
+          $currentString .= $escapedValue;
         }
       } else {
         if ($currentString !== '') {
@@ -275,7 +276,7 @@ final class Renderer {
           if ($item[0] === '$') {
             $combinedArray[] = $item;
           } else {
-            $combinedArray = [...$combinedArray, ...self::concatenateStringMembers($item, $react)];
+            $combinedArray = [...$combinedArray, ...self::concatenateStringMembers($item, $react, $encoding)];
           }
         } else {
           $combinedArray[] = $item;

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -72,7 +72,7 @@ final class Renderer {
         $nodeProps = $this->getNodeProps($node);
 
         $childrenProps = $this->getNodeChildrenProps($node);
-        $props = array_merge($nodeProps ?? [], $childrenProps);
+        $props = array_merge($nodeProps, $childrenProps);
 
         if (!is_string($type) && $type instanceof \Closure) {
           $arity = $this->arityCache[$type] ?? ($this->arityCache[$type] = (new \ReflectionFunction($type))->getNumberOfParameters());
@@ -183,8 +183,6 @@ final class Renderer {
 
         $attributeString = implode(" ", $attributeString);
 
-        $childrenRendered = '';
-
         if (is_string($children)) {
           $childrenRendered = $shouldEscapeHtml ? htmlspecialchars($children, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) : $children;
         } else {
@@ -208,7 +206,7 @@ final class Renderer {
 
         $previousChildWasElement = false;
 
-        foreach ($children as $i => $child) {
+        foreach ($children as $child) {
           if (is_array($child)) {
             if ($child[0] === '$') {
               $_child = $this->renderNode($child, $nesting);
@@ -227,8 +225,6 @@ final class Renderer {
           } else if (is_string($child) || is_numeric($child)) {
             $childrenRendered[] = $this->renderNode($child, $nesting + 1);
             $previousChildWasElement = false;
-          } else {
-            continue;
           }
         }
 

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -32,7 +32,13 @@ final class Renderer {
   }
 
   public function getNodeProps(array $node): array {
-    return $node[2] ?? [];
+    if (!array_key_exists(2, $node) || $node[2] === null) {
+      return [];
+    }
+    if (!is_array($node[2])) {
+      throw new \InvalidArgumentException("Serialized node props (index 2) must be an array or null, got `" . gettype($node[2]) . "` instead.");
+    }
+    return $node[2];
   }
 
   /**
@@ -101,6 +107,11 @@ final class Renderer {
 
         if (array_key_exists($type, $this->components)) {
           return $this->renderNode($this->callComponent($this->components[$type], $props), $nesting);
+        }
+
+        // Validate the tag name to prevent tag-name injection
+        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9\-\.]*$/', $type)) {
+          throw new \InvalidArgumentException("Invalid HTML tag name: `{$type}`");
         }
 
         $shouldEscapeHtml = true;

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -167,7 +167,7 @@ final class Renderer {
                 $_flattened[] = $a;
               });
 
-              $value = implode(" ", $_flattened);
+              $value = htmlspecialchars(implode(" ", $_flattened), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
             } else if ($value instanceof \JsonSerializable) {
               $value = htmlspecialchars(json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES);
             } else if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -156,7 +156,7 @@ final class Renderer {
                 } else if (is_null($dataValue)) {
                   continue;
                 } else {
-                  throw new \Exception("Invalid prop value type: `" . gettype($dataValue) . "``");
+                  throw new \Exception("Invalid prop value type: `" . gettype($dataValue) . "`");
                 }
 
                 $attributeString[] = "data-$dataKey=\"$dataValue\"";
@@ -244,7 +244,7 @@ final class Renderer {
         return implode('', $childrenRendered);
       }
     } else {
-      throw new \Exception("Invalid node type: `" . gettype($node) . "``");
+      throw new \Exception("Invalid node type: `" . gettype($node) . "`");
     }
   }
 

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -150,8 +150,7 @@ final class Renderer {
             $key = 'for';
           }
 
-          // Transform key from camelCase to kebab-case
-          $key = strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $key));
+          $key = strtolower($key);
 
           // Validate attribute name to prevent name-injection attacks
           if (!preg_match('/^[a-z][a-z0-9\-:._]*$/', $key)) {
@@ -173,8 +172,6 @@ final class Renderer {
                 $styleString .= "$styleKey:$styleValue;";
               }
               $value = htmlspecialchars(rtrim($styleString, ';'), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
-            } else if (is_string($value) || is_numeric($value)) {
-              $value = htmlspecialchars((string) $value, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
             } else if ($key === "data" && (is_object($value) || is_array($value))) {
               foreach ((array) $value as $dataKey => $dataValue) {
                 // Normalize data key to kebab-case and validate to prevent name-injection
@@ -189,19 +186,15 @@ final class Renderer {
                   }
 
                   continue;
-                } else if (is_string($dataValue) || is_numeric($dataValue)) {
-                  $dataValue = htmlspecialchars((string) $dataValue, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
                 } else if (is_null($dataValue)) {
                   continue;
-                } else {
-                  throw new \Exception("Invalid prop value type: `" . gettype($dataValue) . "`");
                 }
 
-                $attributeString[] = "data-$dataKey=\"$dataValue\"";
+                $attributeString[] = "data-$dataKey=\"" . htmlspecialchars((string) $dataValue, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) . "\"";
               }
 
               continue;
-            } else if ($key !== 'data' && is_array($value)) {
+            } else if (is_array($value)) {
               $_flattened = [];
 
               // Flatten array
@@ -210,22 +203,10 @@ final class Renderer {
               });
 
               $value = htmlspecialchars(implode(" ", $_flattened), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
-            } else if ($value instanceof \JsonSerializable) {
-              $value = htmlspecialchars(json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
-            } else if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
-              $value = $value->format('c');
-            } else if ($value instanceof \stdClass) {
-              $value = htmlspecialchars(json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES);
+            } else if ($value instanceof \DateTimeInterface) {
+              $value = $value->format('Y-m-d\TH:i:s');
             } else {
-              if (gettype($value) === 'object') {
-                if (method_exists($value, '__toString')) {
-                  $value = (string) $value;
-                } else {
-                  throw new \Exception("Invalid prop `{$key}` value type: `" . gettype($value) . "``");
-                }
-              } else {
-                throw new \Exception("Invalid prop `{$key}` value type: `" . gettype($value) . "``");
-              }
+              $value = htmlspecialchars((string) $value, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
             }
 
             $attributeString[] = "$key=\"$value\"";

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -22,6 +22,12 @@ final class Renderer {
     if (!array_key_exists(0, $node) || $node[0] !== '$') {
       throw new \InvalidArgumentException("Serialized node requires first element to be '$', got `" . (array_key_exists(0, $node) ? $node[0] : 'undefined') . "` instead.");
     }
+    if (!array_key_exists(1, $node)) {
+      throw new \InvalidArgumentException("Serialized node is missing the type at index 1.");
+    }
+    if (!is_string($node[1]) && !($node[1] instanceof \Closure)) {
+      throw new \InvalidArgumentException("Serialized node type must be a string or Closure, got `" . gettype($node[1]) . "` instead.");
+    }
     return $node[1];
   }
 
@@ -126,6 +132,11 @@ final class Renderer {
           // Transform key from camelCase to kebab-case
           $key = strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $key));
 
+          // Validate attribute name to prevent name-injection attacks
+          if (!preg_match('/^[a-z][a-z0-9\-:._]*$/', $key)) {
+            throw new \InvalidArgumentException("Invalid attribute name: `{$key}`");
+          }
+
           if ($value !== null) {
             if (is_bool($value)) {
               if ($value === true) {
@@ -145,6 +156,12 @@ final class Renderer {
               $value = htmlspecialchars((string) $value, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
             } else if ($key === "data" && (is_object($value) || is_array($value))) {
               foreach ((array) $value as $dataKey => $dataValue) {
+                // Normalize data key to kebab-case and validate to prevent name-injection
+                $dataKey = strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', (string) $dataKey));
+                if (!preg_match('/^[a-z][a-z0-9\-:._]*$/', $dataKey)) {
+                  throw new \InvalidArgumentException("Invalid data attribute key: `{$dataKey}`");
+                }
+
                 if (is_bool($dataValue)) {
                   if ($dataValue === true) {
                     $attributeString[] = "data-$dataKey";
@@ -173,7 +190,7 @@ final class Renderer {
 
               $value = htmlspecialchars(implode(" ", $_flattened), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
             } else if ($value instanceof \JsonSerializable) {
-              $value = htmlspecialchars(json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES);
+              $value = htmlspecialchars(json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
             } else if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
               $value = $value->format('c');
             } else if ($value instanceof \stdClass) {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -102,16 +102,13 @@ final class Renderer {
         return '';
       } else if ($node[0] === '$') {
         $type = $this->getNodeType($node);
-        if (!is_string($type) && !($type instanceof \Closure)) {
-          throw new \InvalidArgumentException("Type must be a string or closure, got " . gettype($type) . ".");
-        }
 
         $nodeProps = $this->getNodeProps($node);
 
         $childrenProps = $this->getNodeChildrenProps($node);
         $props = array_merge($nodeProps, $childrenProps);
 
-        if (!is_string($type) && $type instanceof \Closure) {
+        if ($type instanceof \Closure) {
           return $this->renderNode($this->callComponent($type, $props), $nesting);
         }
 

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -76,6 +76,9 @@ final class Renderer {
 
         if (!is_string($type) && $type instanceof \Closure) {
           $arity = $this->arityCache[$type] ?? ($this->arityCache[$type] = (new \ReflectionFunction($type))->getNumberOfParameters());
+          if ($arity > 1) {
+            throw new \InvalidArgumentException("Component closure must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
+          }
           $result = $arity === 0 ? $type() : $type($props);
           return $this->renderNode($result, $nesting);
         }

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -19,7 +19,9 @@ final class Renderer {
   }
 
   public function getNodeType(array $node): string|\Closure {
-    assert($node[0] === '$', "Serialized node requires first element to be '$', got `{$node[0]}` instead.");
+    if (!array_key_exists(0, $node) || $node[0] !== '$') {
+      throw new \InvalidArgumentException("Serialized node requires first element to be '$', got `" . (array_key_exists(0, $node) ? $node[0] : 'undefined') . "` instead.");
+    }
     return $node[1];
   }
 

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -84,7 +84,17 @@ final class Renderer {
         }
 
         if (array_key_exists($type, $this->components)) {
-          return $this->renderNode(call_user_func($this->components[$type], $props), $nesting);
+          $component = $this->components[$type];
+          if ($component instanceof \Closure) {
+            $arity = $this->arityCache[$component] ?? ($this->arityCache[$component] = (new \ReflectionFunction($component))->getNumberOfParameters());
+            if ($arity > 1) {
+              throw new \InvalidArgumentException("Component '{$type}' must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
+            }
+            $result = $arity === 0 ? $component() : $component($props);
+          } else {
+            $result = call_user_func($component, $props);
+          }
+          return $this->renderNode($result, $nesting);
         }
 
         $shouldEscapeHtml = true;

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -78,7 +78,9 @@ final class Renderer {
         return '';
       } else if ($node[0] === '$') {
         $type = $this->getNodeType($node);
-        assert(is_string($type) || $type instanceof \Closure, "Type must be a string or closure.");
+        if (!is_string($type) && !($type instanceof \Closure)) {
+          throw new \InvalidArgumentException("Type must be a string or closure, got " . gettype($type) . ".");
+        }
 
         $nodeProps = $this->getNodeProps($node);
 

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -70,12 +70,22 @@ final class Renderer {
   private function callComponent(\Closure|callable $component, array $props): mixed {
     if ($component instanceof \Closure) {
       $arity = $this->arityCache[$component] ?? ($this->arityCache[$component] = (new \ReflectionFunction($component))->getNumberOfParameters());
-      if ($arity > 1) {
-        throw new \InvalidArgumentException("Component must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
-      }
-      return $arity === 0 ? $component() : $component($props);
+    } else if (is_array($component)) {
+      // [$object|$class, $method]
+      $rf = new \ReflectionMethod($component[0], $component[1]);
+      $arity = $rf->getNumberOfParameters();
+    } else if (is_string($component) && str_contains($component, '::')) {
+      [$class, $method] = explode('::', $component, 2);
+      $rf = new \ReflectionMethod($class, $method);
+      $arity = $rf->getNumberOfParameters();
+    } else {
+      $arity = (new \ReflectionFunction(\Closure::fromCallable($component)))->getNumberOfParameters();
     }
-    return call_user_func($component, $props);
+
+    if ($arity > 1) {
+      throw new \InvalidArgumentException("Component must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
+    }
+    return $arity === 0 ? call_user_func($component) : call_user_func($component, $props);
   }
 
   protected function format(string $rendered, int $nesting): string {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -8,6 +8,7 @@ final class Renderer {
   public bool $react = false;
   public string $indentation = "\t";
   protected array $components = [];
+  private array $arityCache = [];
 
   public function __construct(protected string $encoding = 'UTF-8') {
   }
@@ -16,7 +17,7 @@ final class Renderer {
     return $this->render($node, $components);
   }
 
-  public function getNodeType(array $node): string {
+  public function getNodeType(array $node): string|\Closure {
     assert($node[0] === '$', "Serialized node requires first element to be '$', got `{$node[0]}` instead.");
     return $node[1];
   }
@@ -51,10 +52,21 @@ final class Renderer {
         return '';
       } else if ($node[0] === '$') {
         $type = $this->getNodeType($node);
-        assert(is_string($type), "Type must be a string");
+        assert(is_string($type) || $type instanceof \Closure, "Type must be a string or callable");
 
         $props = $this->getNodeProps($node);
         $children = $this->getNodeChildren($node);
+
+        if (!is_string($type) && $type instanceof \Closure) {
+          $mergedProps = array_merge(
+            $props ?? [],
+            ($children ?? null) ? ['children' => $children] : []
+          );
+          $id = spl_object_id($type);
+          $arity = $this->arityCache[$id] ?? ($this->arityCache[$id] = (new \ReflectionFunction($type))->getNumberOfParameters());
+          $result = $arity === 0 ? $type() : $type($mergedProps);
+          return $this->renderNode($result, $nesting);
+        }
 
         if (array_key_exists($type, $this->components)) {
           return $this->renderNode(

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -70,14 +70,6 @@ final class Renderer {
   private function callComponent(\Closure|callable $component, array $props): mixed {
     if ($component instanceof \Closure) {
       $arity = $this->arityCache[$component] ?? ($this->arityCache[$component] = (new \ReflectionFunction($component))->getNumberOfParameters());
-    } else if (is_array($component)) {
-      // [$object|$class, $method]
-      $rf = new \ReflectionMethod($component[0], $component[1]);
-      $arity = $rf->getNumberOfParameters();
-    } else if (is_string($component) && str_contains($component, '::')) {
-      [$class, $method] = explode('::', $component, 2);
-      $rf = new \ReflectionMethod($class, $method);
-      $arity = $rf->getNumberOfParameters();
     } else {
       $arity = (new \ReflectionFunction(\Closure::fromCallable($component)))->getNumberOfParameters();
     }
@@ -95,176 +87,164 @@ final class Renderer {
   protected function renderNode(bool|int|float|string|array|null $node, int $nesting): string {
     if (is_string($node) || is_numeric($node)) {
       return htmlspecialchars((string) $node, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
-    } else if (is_bool($node) || is_null($node)) {
+    }
+    if (is_bool($node) || is_null($node)) {
       return '';
-    } else if (is_array($node)) {
-      if (empty($node)) {
-        return '';
-      } else if ($node[0] === '$') {
-        $type = $this->getNodeType($node);
-
-        $nodeProps = $this->getNodeProps($node);
-
-        $childrenProps = $this->getNodeChildrenProps($node);
-        $props = array_merge($nodeProps, $childrenProps);
-
-        if ($type instanceof \Closure) {
-          return $this->renderNode($this->callComponent($type, $props), $nesting);
-        }
-
-        if (array_key_exists($type, $this->components)) {
-          return $this->renderNode($this->callComponent($this->components[$type], $props), $nesting);
-        }
-
-        // Validate the tag name to prevent tag-name injection
-        if (!preg_match('/^[a-zA-Z][a-zA-Z0-9\-\.]*$/', $type)) {
-          throw new \InvalidArgumentException("Invalid HTML tag name: `{$type}`");
-        }
-
-        $shouldEscapeHtml = true;
-
-        if (array_key_exists('dangerouslySetInnerHTML', $props)) {
-          $children = $props['dangerouslySetInnerHTML'];
-          unset($props['dangerouslySetInnerHTML']);
-          $shouldEscapeHtml = false;
-
-          if (array_key_exists('children', $props)) {
-            // Throw error in development mode
-            throw new \Exception("Can't use children and dangerouslySetInnerHTML at the same time");
-          }
-        } else {
-          $children = $props['children'] ?? [];
-        }
-
-        unset($props['children']);
-
-        $attributeString = [];
-
-        foreach ($props as $key => $value) {
-          if ($key === 'className') {
-            $key = 'class';
-          } else if ($key === 'htmlFor') {
-            $key = 'for';
-          }
-
-          $key = strtolower($key);
-
-          // Validate attribute name to prevent name-injection attacks
-          if (!preg_match('/^[a-z][a-z0-9\-:._]*$/', $key)) {
-            throw new \InvalidArgumentException("Invalid attribute name: `{$key}`");
-          }
-
-          if ($value !== null) {
-            if (is_bool($value)) {
-              if ($value === true) {
-                $attributeString[] = $key;
-              }
-
-              continue;
-            } else if ($key === "style" && (is_object($value) || is_array($value))) {
-              $styleString = "";
-              foreach ((array) $value as $styleKey => $styleValue) {
-                // Transform key from camelCase to kebab-case
-                $styleKey = strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $styleKey));
-                $styleString .= "$styleKey:$styleValue;";
-              }
-              $value = htmlspecialchars(rtrim($styleString, ';'), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
-            } else if ($key === "data" && (is_object($value) || is_array($value))) {
-              foreach ((array) $value as $dataKey => $dataValue) {
-                // Normalize data key to kebab-case and validate to prevent name-injection
-                $dataKey = strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', (string) $dataKey));
-                if (!preg_match('/^[a-z][a-z0-9\-:._]*$/', $dataKey)) {
-                  throw new \InvalidArgumentException("Invalid data attribute key: `{$dataKey}`");
-                }
-
-                if (is_bool($dataValue)) {
-                  if ($dataValue === true) {
-                    $attributeString[] = "data-$dataKey";
-                  }
-
-                  continue;
-                } else if (is_null($dataValue)) {
-                  continue;
-                }
-
-                $attributeString[] = "data-$dataKey=\"" . htmlspecialchars((string) $dataValue, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) . "\"";
-              }
-
-              continue;
-            } else if (is_array($value)) {
-              $_flattened = [];
-
-              // Flatten array
-              array_walk_recursive($value, function ($a) use (&$_flattened) {
-                $_flattened[] = $a;
-              });
-
-              $value = htmlspecialchars(implode(" ", $_flattened), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
-            } else if ($value instanceof \DateTimeInterface) {
-              $value = $value->format('Y-m-d\TH:i:s');
-            } else {
-              $value = htmlspecialchars((string) $value, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
-            }
-
-            $attributeString[] = "$key=\"$value\"";
-          }
-        }
-
-        $attributeString = implode(" ", $attributeString);
-
-        if (is_string($children)) {
-          $childrenRendered = $shouldEscapeHtml ? htmlspecialchars($children, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) : $children;
-        } else {
-          $childrenRendered = $this->renderNode($children, $nesting + 1);
-
-          if ($this->pretty && (strstr($childrenRendered, "\n") || strstr($childrenRendered, "<"))) {
-            $childrenRendered = "\n".$this->format($childrenRendered, $nesting + 1)."\n".$this->format('', $nesting);
-          }
-        }
-
-        // Handle void elements:
-        if (in_array($type, ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'])) {
-          return "<$type".(empty($attributeString) ? '' : ' ' . $attributeString).($this->void ? ">" : " />");
-        } else {
-          return "<$type".(empty($attributeString) ? '' : ' ' . $attributeString).">{$childrenRendered}</$type>";
-        }
-      } else {
-        $children = self::concatenateStringMembers($node, $this->react, $this->encoding);
-
-        $childrenRendered = [];
-
-        $previousChildWasElement = false;
-
-        foreach ($children as $child) {
-          if (is_array($child)) {
-            if (!array_key_exists(0, $child)) {
-              throw new \InvalidArgumentException("Fragment child must be a serialized node array (starting with '\$') or a nested children array, got an associative or empty array instead.");
-            }
-            if ($child[0] === '$') {
-              $_child = $this->renderNode($child, $nesting);
-
-              if ($this->pretty) {
-                if ($previousChildWasElement) {
-                  $_child = "\n".$this->format($_child, $nesting);
-                }
-              }
-
-              $childrenRendered[] = $_child;
-              $previousChildWasElement = true;
-            } else {
-              throw new \Exception("Unexpected unflattened array in children");
-            }
-          } else if (is_string($child) || is_numeric($child)) {
-            $childrenRendered[] = (string) $child;
-            $previousChildWasElement = false;
-          }
-        }
-
-        return implode('', $childrenRendered);
-      }
-    } else {
+    }
+    if (!is_array($node)) {
       throw new \Exception("Invalid node type: `" . gettype($node) . "`");
     }
+    if (empty($node)) {
+      return '';
+    }
+    if (($node[0] ?? null) !== '$') {
+      return $this->renderFragment($node, $nesting);
+    }
+
+    $type = $this->getNodeType($node);
+    $props = $this->getNodeProps($node);
+    if (array_key_exists(3, $node)) {
+      $props['children'] = $node[3];
+    }
+
+    if ($type instanceof \Closure || array_key_exists($type, $this->components)) {
+      $component = $type instanceof \Closure ? $type : $this->components[$type];
+      return $this->renderNode($this->callComponent($component, $props), $nesting);
+    }
+
+    if (!preg_match('/^[a-zA-Z][a-zA-Z0-9\-\.]*$/', $type)) {
+      throw new \InvalidArgumentException("Invalid HTML tag name: `{$type}`");
+    }
+
+    if (array_key_exists('dangerouslySetInnerHTML', $props)) {
+      if (array_key_exists('children', $props)) {
+        throw new \Exception("Can't use children and dangerouslySetInnerHTML at the same time");
+      }
+      $children = $props['dangerouslySetInnerHTML'];
+      $escapeChildren = false;
+      unset($props['dangerouslySetInnerHTML']);
+    } else {
+      $children = $props['children'] ?? [];
+      $escapeChildren = true;
+    }
+
+    unset($props['children']);
+
+    $attrs = $this->renderAttributes($props);
+
+    if (is_string($children)) {
+      $childrenHtml = $escapeChildren
+        ? htmlspecialchars($children, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding)
+        : $children;
+    } else {
+      $childrenHtml = $this->renderNode($children, $nesting + 1);
+      if ($this->pretty && (strstr($childrenHtml, "\n") || strstr($childrenHtml, "<"))) {
+        $childrenHtml = "\n" . $this->format($childrenHtml, $nesting + 1) . "\n" . $this->format('', $nesting);
+      }
+    }
+
+    $open = "<$type" . ($attrs !== '' ? " $attrs" : '');
+    if (in_array($type, ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'])) {
+      return $open . ($this->void ? '>' : ' />');
+    }
+    return "$open>$childrenHtml</$type>";
+  }
+
+  private function renderAttributes(array $props): string {
+    $parts = [];
+
+    foreach ($props as $key => $value) {
+      if ($key === 'className')
+        $key = 'class';
+      else if ($key === 'htmlFor')
+        $key = 'for';
+
+      $key = strtolower($key);
+
+      if (!preg_match('/^[a-z][a-z0-9\-:._]*$/', $key)) {
+        throw new \InvalidArgumentException("Invalid attribute name: `{$key}`");
+      }
+
+      if ($value === null)
+        continue;
+
+      if (is_bool($value)) {
+        if ($value)
+          $parts[] = $key;
+        continue;
+      }
+
+      if ($key === 'style' && (is_array($value) || is_object($value))) {
+        $css = '';
+        foreach ((array) $value as $prop => $val) {
+          $css .= strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $prop)) . ":$val;";
+        }
+        $parts[] = "style=\"" . htmlspecialchars(rtrim($css, ';'), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) . "\"";
+        continue;
+      }
+
+      if ($key === 'data' && (is_array($value) || is_object($value))) {
+        foreach ((array) $value as $dataKey => $dataValue) {
+          $dataKey = strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', (string) $dataKey));
+          if (!preg_match('/^[a-z][a-z0-9\-:._]*$/', $dataKey)) {
+            throw new \InvalidArgumentException("Invalid data attribute key: `{$dataKey}`");
+          }
+          if ($dataValue === null)
+            continue;
+          if (is_bool($dataValue)) {
+            if ($dataValue)
+              $parts[] = "data-$dataKey";
+            continue;
+          }
+          $parts[] = "data-$dataKey=\"" . htmlspecialchars((string) $dataValue, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) . "\"";
+        }
+        continue;
+      }
+
+      if (is_array($value)) {
+        $flat = [];
+        array_walk_recursive($value, function ($v) use (&$flat) {
+          $flat[] = $v; });
+        $parts[] = "$key=\"" . htmlspecialchars(implode(' ', $flat), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) . "\"";
+        continue;
+      }
+
+      if ($value instanceof \DateTimeInterface) {
+        $parts[] = "$key=\"{$value->format('Y-m-d\TH:i:s')}\"";
+        continue;
+      }
+
+      $parts[] = "$key=\"" . htmlspecialchars((string) $value, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) . "\"";
+    }
+
+    return implode(' ', $parts);
+  }
+
+  private function renderFragment(array $node, int $nesting): string {
+    $parts = [];
+    $previousWasElement = false;
+
+    foreach (self::concatenateStringMembers($node, $this->react, $this->encoding) as $child) {
+      if (is_array($child)) {
+        if (!array_key_exists(0, $child)) {
+          throw new \InvalidArgumentException("Fragment child must be a serialized node array (starting with '\$') or a nested children array, got an associative or empty array instead.");
+        }
+        if ($child[0] !== '$') {
+          throw new \Exception("Unexpected unflattened array in children");
+        }
+        $rendered = $this->renderNode($child, $nesting);
+        if ($this->pretty && $previousWasElement) {
+          $rendered = "\n" . $this->format($rendered, $nesting);
+        }
+        $parts[] = $rendered;
+        $previousWasElement = true;
+      } else if (is_string($child) || is_numeric($child)) {
+        $parts[] = (string) $child;
+        $previousWasElement = false;
+      }
+    }
+
+    return implode('', $parts);
   }
 
   protected static function concatenateStringMembers(array $array, bool $react, string $encoding = 'UTF-8'): array {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -8,9 +8,10 @@ final class Renderer {
   public bool $react = false;
   public string $indentation = "\t";
   protected array $components = [];
-  private array $arityCache = [];
+  private \WeakMap $arityCache;
 
   public function __construct(protected string $encoding = 'UTF-8') {
+    $this->arityCache = new \WeakMap();
   }
 
   public function __invoke(bool|int|float|string|array|null $node, array $components = []): string {
@@ -74,8 +75,7 @@ final class Renderer {
         $mergedProps = array_merge($props ?? [], $childrenProps);
 
         if (!is_string($type) && $type instanceof \Closure) {
-          $id = spl_object_id($type);
-          $arity = $this->arityCache[$id] ?? ($this->arityCache[$id] = (new \ReflectionFunction($type))->getNumberOfParameters());
+          $arity = $this->arityCache[$type] ?? ($this->arityCache[$type] = (new \ReflectionFunction($type))->getNumberOfParameters());
           $result = $arity === 0 ? $type() : $type($mergedProps);
           return $this->renderNode($result, $nesting);
         }

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -26,8 +26,22 @@ final class Renderer {
     return $node[2] ?? [];
   }
 
+  /**
+   * @deprecated Use getNodeChildrenProps instead.
+   */
   public function getNodeChildren(array $node): bool|int|float|string|array|null {
     return $node[3] ?? $this->getNodeProps($node)['children'] ?? [];
+  }
+
+  public function getNodeChildrenProps(array $node): array {
+    if (array_key_exists(3, $node)) {
+      return ['children' => $node[3]];
+    }
+    $props = $this->getNodeProps($node);
+    if (array_key_exists('children', $props)) {
+      return ['children' => $props['children']];
+    }
+    return [];
   }
 
   public function render(bool|int|float|string|array|null $node, array $components = []): string {
@@ -56,9 +70,8 @@ final class Renderer {
 
         $props = $this->getNodeProps($node);
 
-        $hasChildren = array_key_exists(3, $node) || array_key_exists('children', $props);
-        $children = $this->getNodeChildren($node);
-        $mergedProps = array_merge($props ?? [], $hasChildren ? ['children' => $children] : []);
+        $childrenProps = $this->getNodeChildrenProps($node);
+        $mergedProps = array_merge($props ?? [], $childrenProps);
 
         if (!is_string($type) && $type instanceof \Closure) {
           $id = spl_object_id($type);
@@ -82,6 +95,8 @@ final class Renderer {
             // Throw error in development mode
             throw new \Exception("Can't use children and dangerouslySetInnerHTML at the same time");
           }
+        } else {
+          $children = $mergedProps['children'] ?? [];
         }
 
         unset($props['children']);

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -130,9 +130,9 @@ final class Renderer {
                 $styleKey = strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $styleKey));
                 $styleString .= "$styleKey:$styleValue;";
               }
-              $value = rtrim($styleString, ';');
+              $value = htmlspecialchars(rtrim($styleString, ';'), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
             } else if (is_string($value) || is_numeric($value)) {
-              $value = (string) $value;
+              $value = htmlspecialchars((string) $value, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
             } else if ($key === "data" && (is_object($value) || is_array($value))) {
               foreach ((array) $value as $dataKey => $dataValue) {
                 if (is_bool($dataValue)) {
@@ -142,7 +142,7 @@ final class Renderer {
 
                   continue;
                 } else if (is_string($dataValue) || is_numeric($dataValue)) {
-                  $dataValue = (string) $dataValue;
+                  $dataValue = htmlspecialchars((string) $dataValue, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
                 } else if (is_null($dataValue)) {
                   continue;
                 } else {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -238,6 +238,9 @@ final class Renderer {
 
         foreach ($children as $child) {
           if (is_array($child)) {
+            if (!array_key_exists(0, $child)) {
+              throw new \InvalidArgumentException("Fragment child must be a serialized node array (starting with '\$') or a nested children array, got an associative or empty array instead.");
+            }
             if ($child[0] === '$') {
               $_child = $this->renderNode($child, $nesting);
 
@@ -303,6 +306,9 @@ final class Renderer {
         }
 
         if (is_array($item)) {
+          if (!array_key_exists(0, $item)) {
+            throw new \InvalidArgumentException("Fragment child must be a serialized node array (starting with '\$') or a nested children array, got an associative or empty array instead.");
+          }
           if ($item[0] === '$') {
             $combinedArray[] = $item;
           } else {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -59,7 +59,7 @@ final class Renderer {
 
   protected function renderNode(bool|int|float|string|array|null $node, int $nesting): string {
     if (is_string($node) || is_numeric($node)) {
-      return (string) $node;
+      return htmlspecialchars((string) $node, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
     } else if (is_bool($node) || is_null($node)) {
       return '';
     } else if (is_array($node)) {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -38,9 +38,9 @@ final class Renderer {
     if (array_key_exists(3, $node)) {
       return ['children' => $node[3]];
     }
-    $props = $this->getNodeProps($node);
-    if (array_key_exists('children', $props)) {
-      return ['children' => $props['children']];
+    $nodeProps = $this->getNodeProps($node);
+    if (array_key_exists('children', $nodeProps)) {
+      return ['children' => $nodeProps['children']];
     }
     return [];
   }
@@ -69,19 +69,19 @@ final class Renderer {
         $type = $this->getNodeType($node);
         assert(is_string($type) || $type instanceof \Closure, "Type must be a string or closure.");
 
-        $props = $this->getNodeProps($node);
+        $nodeProps = $this->getNodeProps($node);
 
         $childrenProps = $this->getNodeChildrenProps($node);
-        $mergedProps = array_merge($props ?? [], $childrenProps);
+        $props = array_merge($nodeProps ?? [], $childrenProps);
 
         if (!is_string($type) && $type instanceof \Closure) {
           $arity = $this->arityCache[$type] ?? ($this->arityCache[$type] = (new \ReflectionFunction($type))->getNumberOfParameters());
-          $result = $arity === 0 ? $type() : $type($mergedProps);
+          $result = $arity === 0 ? $type() : $type($props);
           return $this->renderNode($result, $nesting);
         }
 
         if (array_key_exists($type, $this->components)) {
-          return $this->renderNode(call_user_func($this->components[$type], $mergedProps), $nesting);
+          return $this->renderNode(call_user_func($this->components[$type], $props), $nesting);
         }
 
         $shouldEscapeHtml = true;
@@ -96,7 +96,7 @@ final class Renderer {
             throw new \Exception("Can't use children and dangerouslySetInnerHTML at the same time");
           }
         } else {
-          $children = $mergedProps['children'] ?? [];
+          $children = $props['children'] ?? [];
         }
 
         unset($props['children']);
@@ -158,7 +158,7 @@ final class Renderer {
                 $_flattened[] = $a;
               });
 
-              $value = implode(" ", $value);
+              $value = implode(" ", $_flattened);
             } else if ($value instanceof \JsonSerializable) {
               $value = htmlspecialchars(json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES);
             } else if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
@@ -204,7 +204,6 @@ final class Renderer {
       } else {
         $children = self::concatenateStringMembers($node, $this->react);
 
-        $elements = 0;
         $childrenRendered = [];
 
         $previousChildWasElement = false;
@@ -212,7 +211,6 @@ final class Renderer {
         foreach ($children as $i => $child) {
           if (is_array($child)) {
             if ($child[0] === '$') {
-              $elements++;
               $_child = $this->renderNode($child, $nesting);
 
               if ($this->pretty) {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -7,10 +7,10 @@ final class Renderer {
   public bool $pretty = false;
   public bool $react = false;
   public string $indentation = "\t";
-  protected array $components = [];
+  private array $components = [];
   private \WeakMap $arityCache;
 
-  public function __construct(protected string $encoding = 'UTF-8') {
+  public function __construct(private string $encoding = 'UTF-8') {
     $this->arityCache = new \WeakMap();
   }
 
@@ -18,7 +18,7 @@ final class Renderer {
     return $this->render($node, $components);
   }
 
-  public function getNodeType(array $node): string|\Closure {
+  private function getNodeType(array $node): string|\Closure {
     if (!array_key_exists(0, $node) || $node[0] !== '$') {
       throw new \InvalidArgumentException("Serialized node requires first element to be '$', got `" . (array_key_exists(0, $node) ? $node[0] : 'undefined') . "` instead.");
     }
@@ -31,7 +31,7 @@ final class Renderer {
     return $node[1];
   }
 
-  public function getNodeProps(array $node): array {
+  private function getNodeProps(array $node): array {
     if (!array_key_exists(2, $node) || $node[2] === null) {
       return [];
     }
@@ -39,10 +39,6 @@ final class Renderer {
       throw new \InvalidArgumentException("Serialized node props (index 2) must be an array or null, got `" . gettype($node[2]) . "` instead.");
     }
     return $node[2];
-  }
-
-  public function getNodeChildren(array $node): bool|int|float|string|array|null {
-    return $node[3] ?? $this->getNodeProps($node)['children'] ?? [];
   }
 
   public function render(bool|int|float|string|array|null $node, array $components = []): string {
@@ -53,28 +49,28 @@ final class Renderer {
     return $html;
   }
 
-  private function callComponent(\Closure|callable $component, array $props): mixed {
-    $fn = $component instanceof \Closure ? $component : \Closure::fromCallable($component);
-    $arity = $this->arityCache[$fn] ?? ($this->arityCache[$fn] = (new \ReflectionFunction($fn))->getNumberOfParameters());
+  private function callComponent(callable $component, array $props): mixed {
+    if ($component instanceof \Closure) {
+      $arity = $this->arityCache[$component] ??= (new \ReflectionFunction($component))->getNumberOfParameters();
+    } else {
+      $arity = (new \ReflectionFunction(\Closure::fromCallable($component)))->getNumberOfParameters();
+    }
     if ($arity > 1) {
       throw new \InvalidArgumentException("Component must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
     }
-    return $arity === 0 ? $fn() : $fn($props);
+    return $arity === 0 ? $component() : $component($props);
   }
 
-  protected function format(string $rendered, int $nesting): string {
+  private function format(string $rendered, int $nesting): string {
     return str_repeat($this->indentation, max(0, $nesting)).$rendered;
   }
 
-  protected function renderNode(bool|int|float|string|array|null $node, int $nesting): string {
+  private function renderNode(bool|int|float|string|array|null $node, int $nesting): string {
     if (is_string($node) || is_numeric($node)) {
       return htmlspecialchars((string) $node, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
     }
     if (is_bool($node) || is_null($node)) {
       return '';
-    }
-    if (!is_array($node)) {
-      throw new \Exception("Invalid node type: `" . gettype($node) . "`");
     }
     if (empty($node)) {
       return '';
@@ -102,7 +98,11 @@ final class Renderer {
       if (array_key_exists('children', $props)) {
         throw new \Exception("Can't use children and dangerouslySetInnerHTML at the same time");
       }
-      $children = $props['dangerouslySetInnerHTML'];
+      $raw = $props['dangerouslySetInnerHTML'];
+      if (!is_array($raw) || !array_key_exists('__html', $raw)) {
+        throw new \InvalidArgumentException("dangerouslySetInnerHTML must be an array with an '__html' key.");
+      }
+      $children = $raw['__html'];
       $escapeChildren = false;
       unset($props['dangerouslySetInnerHTML']);
     } else {
@@ -192,7 +192,7 @@ final class Renderer {
       }
 
       if ($value instanceof \DateTimeInterface) {
-        $parts[] = "$key=\"{$value->format('Y-m-d\TH:i:s')}\"";
+        $parts[] = "$key=\"" . htmlspecialchars($value->format('Y-m-d\TH:i:s'), ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding) . "\"";
         continue;
       }
 
@@ -206,22 +206,16 @@ final class Renderer {
     $parts = [];
     $previousWasElement = false;
 
-    foreach (self::concatenateStringMembers($node, $this->react, $this->encoding) as $child) {
+    foreach ($this->concatenateStringMembers($node) as $child) {
       if (is_array($child)) {
-        if (!array_key_exists(0, $child)) {
-          throw new \InvalidArgumentException("Fragment child must be a serialized node array (starting with '\$') or a nested children array, got an associative or empty array instead.");
-        }
-        if ($child[0] !== '$') {
-          throw new \Exception("Unexpected unflattened array in children");
-        }
         $rendered = $this->renderNode($child, $nesting);
         if ($this->pretty && $previousWasElement) {
           $rendered = "\n" . $this->format($rendered, $nesting);
         }
         $parts[] = $rendered;
         $previousWasElement = true;
-      } else if (is_string($child) || is_numeric($child)) {
-        $parts[] = (string) $child;
+      } else if (is_string($child)) {
+        $parts[] = $child;
         $previousWasElement = false;
       }
     }
@@ -229,54 +223,34 @@ final class Renderer {
     return implode('', $parts);
   }
 
-  protected static function concatenateStringMembers(array $array, bool $react, string $encoding = 'UTF-8'): array {
+  private function concatenateStringMembers(array $array): array {
     $combinedArray = [];
     $currentString = '';
-
     $length = count($array);
 
     foreach ($array as $index => $item) {
-      if (
-        is_string($item) || is_numeric($item)
-      ) {
-        $escapedValue = htmlspecialchars((string) $item, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $encoding);
-        if ($react) {
-          $isFirst = $index === 0;
-          $isLast = $index === $length - 1;
+      if (is_string($item) || is_numeric($item)) {
+        $escapedValue = htmlspecialchars((string) $item, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, $this->encoding);
+        if ($this->react) {
           $stringifiedValue = (string) $item;
-
-          $canBeTrimmedFromStart = !$isFirst && ltrim($stringifiedValue) !== $stringifiedValue;
-          $canBeTrimmedFromEnd = !$isLast && rtrim($stringifiedValue) !== $stringifiedValue;
-
-          if ($canBeTrimmedFromStart && $canBeTrimmedFromEnd) {
-            $currentString .= '<!-- -->' . $escapedValue . '<!-- -->';
-          } else if ($canBeTrimmedFromEnd) {
-            $currentString .= $escapedValue . '<!-- -->';
-          } else if ($canBeTrimmedFromStart) {
-            $currentString .= '<!-- -->' . $escapedValue;
-          } else {
-            $currentString .= $escapedValue;
-          }
+          $prefix = $index !== 0 && ltrim($stringifiedValue) !== $stringifiedValue ? '<!-- -->' : '';
+          $suffix = $index !== $length - 1 && rtrim($stringifiedValue) !== $stringifiedValue ? '<!-- -->' : '';
+          $currentString .= $prefix . $escapedValue . $suffix;
         } else {
           $currentString .= $escapedValue;
         }
-      } else {
+      } else if (is_array($item)) {
         if ($currentString !== '') {
           $combinedArray[] = $currentString;
           $currentString = '';
         }
-
-        if (is_array($item)) {
-          if (!array_key_exists(0, $item)) {
-            throw new \InvalidArgumentException("Fragment child must be a serialized node array (starting with '\$') or a nested children array, got an associative or empty array instead.");
-          }
-          if ($item[0] === '$') {
-            $combinedArray[] = $item;
-          } else {
-            $combinedArray = [...$combinedArray, ...self::concatenateStringMembers($item, $react, $encoding)];
-          }
-        } else {
+        if (!array_key_exists(0, $item)) {
+          throw new \InvalidArgumentException("Fragment child must be a serialized node array (starting with '\$') or a nested children array, got an associative or empty array instead.");
+        }
+        if ($item[0] === '$') {
           $combinedArray[] = $item;
+        } else {
+          $combinedArray = [...$combinedArray, ...$this->concatenateStringMembers($item)];
         }
       }
     }

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -41,22 +41,8 @@ final class Renderer {
     return $node[2];
   }
 
-  /**
-   * @deprecated Use getNodeChildrenProps instead.
-   */
   public function getNodeChildren(array $node): bool|int|float|string|array|null {
     return $node[3] ?? $this->getNodeProps($node)['children'] ?? [];
-  }
-
-  public function getNodeChildrenProps(array $node): array {
-    if (array_key_exists(3, $node)) {
-      return ['children' => $node[3]];
-    }
-    $nodeProps = $this->getNodeProps($node);
-    if (array_key_exists('children', $nodeProps)) {
-      return ['children' => $nodeProps['children']];
-    }
-    return [];
   }
 
   public function render(bool|int|float|string|array|null $node, array $components = []): string {
@@ -68,16 +54,12 @@ final class Renderer {
   }
 
   private function callComponent(\Closure|callable $component, array $props): mixed {
-    if ($component instanceof \Closure) {
-      $arity = $this->arityCache[$component] ?? ($this->arityCache[$component] = (new \ReflectionFunction($component))->getNumberOfParameters());
-    } else {
-      $arity = (new \ReflectionFunction(\Closure::fromCallable($component)))->getNumberOfParameters();
-    }
-
+    $fn = $component instanceof \Closure ? $component : \Closure::fromCallable($component);
+    $arity = $this->arityCache[$fn] ?? ($this->arityCache[$fn] = (new \ReflectionFunction($fn))->getNumberOfParameters());
     if ($arity > 1) {
       throw new \InvalidArgumentException("Component must accept 0 or 1 parameter (\$props). Got {$arity} parameters. Pass children via \$props['children'] instead.");
     }
-    return $arity === 0 ? call_user_func($component) : call_user_func($component, $props);
+    return $arity === 0 ? $fn() : $fn($props);
   }
 
   protected function format(string $rendered, int $nesting): string {

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -622,4 +622,78 @@ HTML;
       ]))->toBe('<span class="from-closure">Content</span>');
     });
   });
+
+  describe('XSS prevention', function () {
+    it('escapes HTML special characters in text node strings', function () {
+      $html = ['$', 'p', null, '<script>alert("xss")</script>'];
+
+      expect((new Renderer)($html))->toBe('<p>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</p>');
+    });
+
+    it('escapes entities in bare string nodes', function () {
+      expect((new Renderer)('<b>bold</b> & "quoted"'))->toBe('&lt;b&gt;bold&lt;/b&gt; &amp; &quot;quoted&quot;');
+    });
+
+    it('escapes HTML tags injected into attribute values', function () {
+      $html = ['$', 'div', ['title' => '<img src=x onerror=alert(1)>']];
+
+      expect((new Renderer)($html))->toBe('<div title="&lt;img src=x onerror=alert(1)&gt;"></div>');
+    });
+
+    it('escapes double-quote injection in attribute values to prevent attribute break-out', function () {
+      $html = ['$', 'div', ['class' => '" onmouseover="alert(1)']];
+
+      expect((new Renderer)($html))->toBe('<div class="&quot; onmouseover=&quot;alert(1)"></div>');
+    });
+
+    it('escapes ampersands in attribute values', function () {
+      $html = ['$', 'a', ['href' => '/search?q=foo&bar=baz']];
+
+      expect((new Renderer)($html))->toBe('<a href="/search?q=foo&amp;bar=baz"></a>');
+    });
+
+    it('escapes single-quote injection in attribute values', function () {
+      $html = ['$', 'div', ['data-value' => "' onmouseover='alert(1)"]];
+
+      expect((new Renderer)($html))->toBe('<div data-value="&apos; onmouseover=&apos;alert(1)"></div>');
+    });
+
+    it('escapes double-quote injection in style attribute values', function () {
+      $html = ['$', 'div', ['style' => (object)['background' => 'red"} *{color:red}']]];
+
+      expect((new Renderer)($html))->toBe('<div style="background:red&quot;} *{color:red}"></div>');
+    });
+
+    it('escapes double-quote injection in data-* attribute values', function () {
+      $html = ['$', 'div', ['data' => (object)['value' => '" onxss="1']]];
+
+      expect((new Renderer)($html))->toBe('<div data-value="&quot; onxss=&quot;1"></div>');
+    });
+
+    it('escapes ampersands in data-* attribute values', function () {
+      $html = ['$', 'div', ['data' => (object)['query' => 'foo&bar']]];
+
+      expect((new Renderer)($html))->toBe('<div data-query="foo&amp;bar"></div>');
+    });
+
+    it('escapes HTML special chars in text node array fragments', function () {
+      $html = ['$', 'p', null, ['<b>bold</b>', ' & ', '"quoted"']];
+
+      expect((new Renderer)($html))->toBe('<p>&lt;b&gt;bold&lt;/b&gt; &amp; &quot;quoted&quot;</p>');
+    });
+
+    it('does not escape dangerouslySetInnerHTML content', function () {
+      $html = ['$', 'div', ['dangerouslySetInnerHTML' => '<b>intentional &amp; safe</b>']];
+
+      expect((new Renderer)($html))->toBe('<div><b>intentional &amp; safe</b></div>');
+    });
+
+    it('escapes script injection passed through a named component prop', function () {
+      $html = ['$', 'Wrapper', ['label' => '<script>alert(1)</script>']];
+
+      expect((new Renderer)($html, [
+        'Wrapper' => fn(array $props) => ['$', 'div', ['title' => $props['label']], null],
+      ]))->toBe('<div title="&lt;script&gt;alert(1)&lt;/script&gt;"></div>');
+    });
+  });
 });

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -688,6 +688,12 @@ HTML;
       expect((new Renderer)($html))->toBe('<div><b>intentional &amp; safe</b></div>');
     });
 
+    it('escapes HTML special chars in array-valued attributes (e.g. class arrays)', function () {
+      $html = ['$', 'div', ['class' => ['container', '" onxss="1']]];
+
+      expect((new Renderer)($html))->toBe('<div class="container &quot; onxss=&quot;1"></div>');
+    });
+
     it('escapes script injection passed through a named component prop', function () {
       $html = ['$', 'Wrapper', ['label' => '<script>alert(1)</script>']];
 

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -159,6 +159,18 @@ describe('Attitude\ArrayRenderer\HTML', function () {
     expect((new Renderer)($html))->toBe($expected);
   });
 
+  it('maps className to class attribute', function () {
+    $html = ['$', 'div', ['className' => 'my-class'], 'content'];
+
+    expect((new Renderer)($html))->toBe('<div class="my-class">content</div>');
+  });
+
+  it('maps htmlFor to for attribute', function () {
+    $html = ['$', 'label', ['htmlFor' => 'input-id'], 'Label'];
+
+    expect((new Renderer)($html))->toBe('<label for="input-id">Label</label>');
+  });
+
   it('handles empty string attributes', function () {
     $html = ['$',  'div', [
       'class' => ['container', 'main-container'],
@@ -196,11 +208,23 @@ describe('Attitude\ArrayRenderer\HTML', function () {
   });
 
   it('handles dangerouslySetInnerHTML', function () {
-    $html = ['$', 'div', ['dangerouslySetInnerHTML' => '<h1>Hello World!</h1>']];
+    $html = ['$', 'div', ['dangerouslySetInnerHTML' => ['__html' => '<h1>Hello World!</h1>']]];
 
     $expected = '<div><h1>Hello World!</h1></div>';
 
     expect((new Renderer)($html))->toBe($expected);
+  });
+
+  it('throws when dangerouslySetInnerHTML and children are both present', function () {
+    $html = ['$', 'div', ['dangerouslySetInnerHTML' => ['__html' => '<b>raw</b>']], 'child text'];
+
+    expect(fn() => (new Renderer)($html))->toThrow(\Exception::class);
+  });
+
+  it('throws when dangerouslySetInnerHTML is not an array with __html key', function () {
+    $html = ['$', 'div', ['dangerouslySetInnerHTML' => '<b>raw</b>']];
+
+    expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
   });
 
   it('handles nested fragments', function () {
@@ -298,7 +322,7 @@ HTML;
           ['$', 'h1', null, [['Blog']]],
           null,
         ]],
-        ['$', 'main', ['dangerouslySetInnerHTML' => '<h2>Recent Articles</h2>']],
+        ['$', 'main', ['dangerouslySetInnerHTML' => ['__html' => '<h2>Recent Articles</h2>']]],
         ['$', 'aside', null, [
           ['$', 'ul', null, [[
             ['$', 'li', null, [['$', 'a', ['href' => '/blog/2024-03-12/index.html'],
@@ -466,7 +490,7 @@ HTML;
                 ['$', 'h1', null, [['Blog']]],
                 null,
               ]],
-              [[['$', 'main', ['dangerouslySetInnerHTML' => '<h2>Recent Articles</h2>']]]],
+              [[['$', 'main', ['dangerouslySetInnerHTML' => ['__html' => '<h2>Recent Articles</h2>']]]]],
               ['$', 'aside', null, [
                 ['$', 'ul', null, [[
                   ['$', 'li', null, [['$', 'a', ['href' => '/blog/2024-03-12/index.html'],
@@ -765,7 +789,7 @@ HTML;
     });
 
     it('does not escape dangerouslySetInnerHTML content', function () {
-      $html = ['$', 'div', ['dangerouslySetInnerHTML' => '<b>intentional &amp; safe</b>']];
+      $html = ['$', 'div', ['dangerouslySetInnerHTML' => ['__html' => '<b>intentional &amp; safe</b>']]];
 
       expect((new Renderer)($html))->toBe('<div><b>intentional &amp; safe</b></div>');
     });
@@ -906,6 +930,20 @@ HTML;
       $html = ['$', 'div', null, 'hello'];
 
       expect((new Renderer)($html))->toBe('<div>hello</div>');
+    });
+  });
+
+  describe('node type validation', function () {
+    it('throws InvalidArgumentException for a node missing the type at index 1', function () {
+      $html = ['$'];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException for a non-string non-Closure node type', function () {
+      $html = ['$', 42];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
     });
   });
 });

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -807,6 +807,36 @@ HTML;
 
       expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
     });
+
+    it('renders onclick attribute with escaped value', function () {
+      $html = ['$', 'div', ['onclick' => 'doSomething()']];
+
+      expect((new Renderer)($html))->toBe('<div onclick="doSomething()"></div>');
+    });
+
+    it('escapes double-quote injection in onclick attribute value', function () {
+      $html = ['$', 'div', ['onclick' => '"injected"']];
+
+      expect((new Renderer)($html))->toBe('<div onclick="&quot;injected&quot;"></div>');
+    });
+
+    it('should never convert camelCase onClick to kebab-case on-click', function () {
+      $html = ['$', 'div', ['onClick' => 'go()']];
+
+      expect((new Renderer)($html))->toBe('<div onclick="go()"></div>');
+    });
+
+    it('formats DateTime as datetime-local value (no timezone offset)', function () {
+      $html = ['$', 'input', ['type' => 'datetime-local', 'value' => new \DateTime('2026-03-22 14:30:00')]];
+
+      expect((new Renderer)($html))->toBe('<input type="datetime-local" value="2026-03-22T14:30:00" />');
+    });
+
+    it('formats DateTimeImmutable as datetime-local value (no timezone offset)', function () {
+      $html = ['$', 'input', ['type' => 'datetime-local', 'value' => new \DateTimeImmutable('2026-03-22 09:05:07')]];
+
+      expect((new Renderer)($html))->toBe('<input type="datetime-local" value="2026-03-22T09:05:07" />');
+    });
   });
 
   describe('fragment child validation', function () {

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -506,6 +506,20 @@ HTML;
       expect((new Renderer)($html))->toBe('Hello from closure!');
     });
 
+    it('escapes HTML special chars in a string returned by a closure', function () {
+      $html = ['$', fn() => '<b>bold</b> & "quoted"', null];
+
+      expect((new Renderer)($html))->toBe('&lt;b&gt;bold&lt;/b&gt; &amp; &quot;quoted&quot;');
+    });
+
+    it('escapes HTML special chars in a string returned by a named component', function () {
+      $html = ['$', 'Dangerous', null];
+
+      expect((new Renderer)($html, [
+        'Dangerous' => fn() => '<script>alert(1)</script>',
+      ]))->toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+
     it('renders a closure returning null', function () {
       $html = ['$', fn() => null, null];
 

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -701,5 +701,47 @@ HTML;
         'Wrapper' => fn(array $props) => ['$', 'div', ['title' => $props['label']], null],
       ]))->toBe('<div title="&lt;script&gt;alert(1)&lt;/script&gt;"></div>');
     });
+
+    it('throws InvalidArgumentException for an attribute name containing whitespace', function () {
+      $html = ['$', 'div', ['bad name' => 'value']];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException for an attribute name containing quotes', function () {
+      $html = ['$', 'div', ['"evil"' => 'value']];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException for an invalid data attribute key', function () {
+      $html = ['$', 'div', ['data' => ['"injected' => 'value']]];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException for an invalid data key containing whitespace', function () {
+      $html = ['$', 'div', ['data' => ['bad key' => 'value']]];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+  });
+
+  describe('fragment child validation', function () {
+    it('throws InvalidArgumentException for an empty array child inside a fragment', function () {
+      $html = ['$', 'div', null, [
+        [],
+      ]];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException for an associative array child (no index 0) inside a fragment', function () {
+      $html = ['$', 'div', null, [
+        ['key' => 'value'],
+      ]];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
   });
 });

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -744,4 +744,56 @@ HTML;
       expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
     });
   });
+
+  describe('tag name validation', function () {
+    it('throws InvalidArgumentException for a tag name containing whitespace', function () {
+      $html = ['$', "div onmouseover=alert(1) x", null];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException for a tag name containing angle brackets', function () {
+      $html = ['$', "div><script>alert(1)</script><div", null];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException for a tag name containing a quote', function () {
+      $html = ['$', 'div"evil', null];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException for a tag name containing a slash', function () {
+      $html = ['$', 'div/script', null];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('accepts valid custom element names with hyphens', function () {
+      $html = ['$', 'my-element', null, 'content'];
+
+      expect((new Renderer)($html))->toBe('<my-element>content</my-element>');
+    });
+  });
+
+  describe('props validation', function () {
+    it('throws InvalidArgumentException when props is a string', function () {
+      $html = ['$', 'div', 'not-an-array'];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('throws InvalidArgumentException when props is an integer', function () {
+      $html = ['$', 'div', 42];
+
+      expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
+    });
+
+    it('treats null props the same as an empty array', function () {
+      $html = ['$', 'div', null, 'hello'];
+
+      expect((new Renderer)($html))->toBe('<div>hello</div>');
+    });
+  });
 });

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -4,6 +4,28 @@ use Attitude\PHPX\Renderer\Renderer;
 
 require_once __DIR__.'/../../src/index.php';
 
+class PhpxTestStaticComponent {
+  public static function render(): array {
+    return ['$', 'b', null, 'static zero'];
+  }
+  public static function renderWithProps(array $props): array {
+    return ['$', 'b', null, $props['text']];
+  }
+}
+
+class PhpxTestInstanceComponent {
+  public function render(): array {
+    return ['$', 'i', null, 'instance zero'];
+  }
+  public function renderWithProps(array $props): array {
+    return ['$', 'i', null, $props['text']];
+  }
+}
+
+function phpx_test_two_arg_component(array $props, string $extra): array {
+  return ['$', 'span', null, $extra];
+}
+
 describe('Attitude\ArrayRenderer\HTML', function () {
   it('generates a string', function () {
     $html = 'Hello World!';
@@ -620,6 +642,66 @@ HTML;
       expect((new Renderer)($html, [
         'Badge' => fn() => ['$', 'div', null, 'Alternative component'],
       ]))->toBe('<span class="from-closure">Content</span>');
+    });
+  });
+
+  describe('Non-Closure callable components', function () {
+    it('calls a 0-arg named function component without props', function () {
+      function phpx_test_zero_arg_component(): array {
+        return ['$', 'span', null, 'from named function'];
+      }
+
+      $html = ['$', 'Foo', null];
+
+      expect((new Renderer)($html, ['Foo' => 'phpx_test_zero_arg_component']))->toBe('<span>from named function</span>');
+    });
+
+    it('calls a 1-arg named function component with props', function () {
+      function phpx_test_one_arg_component(array $props): array {
+        return ['$', 'span', null, $props['label']];
+      }
+
+      $html = ['$', 'Foo', ['label' => 'from props']];
+
+      expect((new Renderer)($html, ['Foo' => 'phpx_test_one_arg_component']))->toBe('<span>from props</span>');
+    });
+
+    it('calls a 0-arg static method component', function () {
+      $html = ['$', 'Foo', null];
+
+      expect((new Renderer)($html, ['Foo' => ['PhpxTestStaticComponent', 'render']]))->toBe('<b>static zero</b>');
+    });
+
+    it('calls a 1-arg static method component with props', function () {
+      $html = ['$', 'Foo', ['text' => 'hello']];
+
+      expect((new Renderer)($html, ['Foo' => ['PhpxTestStaticComponent', 'renderWithProps']]))->toBe('<b>hello</b>');
+    });
+
+    it('calls a 0-arg instance method component', function () {
+      $html = ['$', 'Foo', null];
+      $obj = new PhpxTestInstanceComponent();
+
+      expect((new Renderer)($html, ['Foo' => [$obj, 'render']]))->toBe('<i>instance zero</i>');
+    });
+
+    it('calls a 1-arg instance method component with props', function () {
+      $html = ['$', 'Foo', ['text' => 'world']];
+      $obj = new PhpxTestInstanceComponent();
+
+      expect((new Renderer)($html, ['Foo' => [$obj, 'renderWithProps']]))->toBe('<i>world</i>');
+    });
+
+    it('calls a static method via Class::method string syntax', function () {
+      $html = ['$', 'Foo', null];
+
+      expect((new Renderer)($html, ['Foo' => 'PhpxTestStaticComponent::render']))->toBe('<b>static zero</b>');
+    });
+
+    it('throws when a non-Closure callable has more than 1 parameter', function () {
+      $html = ['$', 'Foo', null];
+
+      expect(fn() => (new Renderer)($html, ['Foo' => 'phpx_test_two_arg_component']))->toThrow(\InvalidArgumentException::class);
     });
   });
 

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -498,4 +498,114 @@ HTML;
 
     expect($renderer($html))->toBe($expected);
   });
+
+  describe('Closure as node type', function () {
+    it('renders a closure returning a string', function () {
+      $html = ['$', fn() => 'Hello from closure!', null];
+
+      expect((new Renderer)($html))->toBe('Hello from closure!');
+    });
+
+    it('renders a closure returning null', function () {
+      $html = ['$', fn() => null, null];
+
+      expect((new Renderer)($html))->toBe('');
+    });
+
+    it('renders a closure returning false', function () {
+      $html = ['$', fn() => false, null];
+
+      expect((new Renderer)($html))->toBe('');
+    });
+
+    it('renders a closure returning an HTML element', function () {
+      $html = ['$', fn() => ['$', 'span', null, 'Closure span'], null];
+
+      expect((new Renderer)($html))->toBe('<span>Closure span</span>');
+    });
+
+    it('renders a closure receiving props', function () {
+      $component = fn(array $props) => ['$', 'p', ['class' => $props['class']], $props['text']];
+
+      $html = ['$', $component, ['class' => 'greeting', 'text' => 'Hi!']];
+
+      expect((new Renderer)($html))->toBe('<p class="greeting">Hi!</p>');
+    });
+
+    it('renders a closure receiving children via props', function () {
+      $component = fn(array $props) => ['$', 'section', null, $props['children']];
+
+      $html = ['$', $component, null, [
+        ['$', 'h2', null, 'Title'],
+        ['$', 'p', null, 'Body'],
+      ]];
+
+      expect((new Renderer)($html))->toBe('<section><h2>Title</h2><p>Body</p></section>');
+    });
+
+    it('renders a closure receiving both props and children', function () {
+      $component = fn(array $props) => [
+        '$', 'div', ['class' => $props['class']], $props['children'],
+      ];
+
+      $html = ['$', $component, ['class' => 'wrapper'], [
+        ['$', 'span', null, 'Inside'],
+      ]];
+
+      expect((new Renderer)($html))->toBe('<div class="wrapper"><span>Inside</span></div>');
+    });
+
+    it('renders a closure that ignores props and returns a static element', function () {
+      $component = fn() => ['$', 'hr', []];
+
+      $html = ['$', $component, ['data-ignored' => 'yes']];
+
+      expect((new Renderer)($html))->toBe('<hr />');
+    });
+
+    it('renders nested closures', function () {
+      $inner = fn(array $props) => ['$', 'em', null, $props['text']];
+      $outer = fn(array $props) => ['$', 'strong', null, ['$', $inner, ['text' => $props['label']]]];
+
+      $html = ['$', $outer, ['label' => 'Nested']];
+
+      expect((new Renderer)($html))->toBe('<strong><em>Nested</em></strong>');
+    });
+
+    it('renders a closure alongside named components', function () {
+      $closure = fn(array $props) => ['$', 'b', null, $props['children']];
+
+      $html = ['$', 'div', null, [
+        ['$', $closure, null, 'Bold text'],
+        ['$', 'Badge', null, 'Labeled'],
+      ]];
+
+      expect((new Renderer)($html, [
+        'Badge' => fn(array $props) => ['$', 'span', ['class' => 'badge'], $props['children']],
+      ]))->toBe('<div><b>Bold text</b><span class="badge">Labeled</span></div>');
+    });
+
+    it('renders a closure returning an array fragment', function () {
+      $component = fn() => [
+        ['$', 'li', null, 'Item 1'],
+        ['$', 'li', null, 'Item 2'],
+      ];
+
+      $html = ['$', 'ul', null, [
+        ['$', $component, null],
+      ]];
+
+      expect((new Renderer)($html))->toBe('<ul><li>Item 1</li><li>Item 2</li></ul>');
+    });
+
+    it('invokes closure node types directly without consulting components map', function () {
+      $closureComponent = fn(array $props) => ['$', 'span', ['class' => 'from-closure'], $props['children']];
+
+      $html = ['$', $closureComponent, null, 'Content'];
+
+      expect((new Renderer)($html, [
+        'Badge' => fn() => ['$', 'div', null, 'Alternative component'],
+      ]))->toBe('<span class="from-closure">Content</span>');
+    });
+  });
 });


### PR DESCRIPTION
Pull request enhances Renderer class with closure support similar to type in JSX, improved HTML escaping, and new utility methods.

> [!CAUTION]
> This PR introduces public API breaking changes. 

Key improvements include:

**Security and Escaping Enhancements**
- String and numeric node values, as well as attribute values, are consistently HTML-escaped using `htmlspecialchars` to prevent XSS vulnerabilities.

**Stricter Validation and Error Handling**
- The renderer throws explicit exceptions for malformed node structures, missing required fields, invalid tag/attribute names, and improper component signatures.
- `getNodeType` and `getNodeProps` methods validate required node fields and throw exceptions for malformed nodes.

**Component and Fragment Handling**
- Components are invoked via a dedicated `callComponent` method that caches arity and enforces a single parameter (props).
- Fragment rendering and flattening logic is hardened with validation and error messages for invalid child arrays.

**Attribute Serialization Improvements**
- Attribute rendering is refactored into a dedicated `renderAttributes` method that normalizes attribute names, handles booleans, arrays, objects, and special cases, and throws for invalid names.
- Data attributes and styles are handled more robustly, including kebab-case conversion and HTML escaping.

**Code Structure and Readability**
- The rendering logic is modularized, separating attribute rendering, fragment rendering, and component invocation for improved maintainability and clarity.

These changes enhance the renderer’s safety, robustness, and usability.