### PR TITLE
feat(Renderer): implement Fragment resolveDangerouslySetInnerHTML

### DIFF
--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -61,6 +61,17 @@ final class Renderer {
     return $arity === 0 ? $component() : $component($props);
   }
 
+  private function resolveDangerouslySetInnerHTML(array $props): string {
+    if (array_key_exists('children', $props)) {
+      throw new \Exception("Can't use children and dangerouslySetInnerHTML at the same time");
+    }
+    $raw = $props['dangerouslySetInnerHTML'];
+    if (!is_array($raw) || !array_key_exists('__html', $raw) || !is_string($raw['__html'])) {
+      throw new \InvalidArgumentException("dangerouslySetInnerHTML must be an array with an '__html' key containing a string.");
+    }
+    return (string) $raw['__html'];
+  }
+
   private function format(string $rendered, int $nesting): string {
     return str_repeat($this->indentation, max(0, $nesting)).$rendered;
   }
@@ -90,19 +101,19 @@ final class Renderer {
       return $this->renderNode($this->callComponent($component, $props), $nesting);
     }
 
+    if ($type === 'Fragment') {
+      if (array_key_exists('dangerouslySetInnerHTML', $props)) {
+        return $this->resolveDangerouslySetInnerHTML($props);
+      }
+      return $this->renderNode($props['children'] ?? [], $nesting);
+    }
+
     if (!preg_match('/^[a-zA-Z][a-zA-Z0-9\-\.]*$/', $type)) {
       throw new \InvalidArgumentException("Invalid HTML tag name: `{$type}`");
     }
 
     if (array_key_exists('dangerouslySetInnerHTML', $props)) {
-      if (array_key_exists('children', $props)) {
-        throw new \Exception("Can't use children and dangerouslySetInnerHTML at the same time");
-      }
-      $raw = $props['dangerouslySetInnerHTML'];
-      if (!is_array($raw) || !array_key_exists('__html', $raw)) {
-        throw new \InvalidArgumentException("dangerouslySetInnerHTML must be an array with an '__html' key.");
-      }
-      $children = $raw['__html'];
+      $children = $this->resolveDangerouslySetInnerHTML($props);
       $escapeChildren = false;
       unset($props['dangerouslySetInnerHTML']);
     } else {

--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -63,7 +63,7 @@ final class Renderer {
 
   private function resolveDangerouslySetInnerHTML(array $props): string {
     if (array_key_exists('children', $props)) {
-      throw new \Exception("Can't use children and dangerouslySetInnerHTML at the same time");
+      throw new \InvalidArgumentException("Can't use children and dangerouslySetInnerHTML at the same time");
     }
     $raw = $props['dangerouslySetInnerHTML'];
     if (!is_array($raw) || !array_key_exists('__html', $raw) || !is_string($raw['__html'])) {

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -254,7 +254,7 @@ describe('Attitude\ArrayRenderer\HTML', function () {
   it('throws when Fragment receives both dangerouslySetInnerHTML and children', function () {
     $html = ['$', 'Fragment', ['dangerouslySetInnerHTML' => ['__html' => '<b>raw</b>']], 'child text'];
 
-    expect(fn() => (new Renderer)($html))->toThrow(\Exception::class);
+    expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
   });
 
   it('handles nested fragments', function () {

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -227,6 +227,36 @@ describe('Attitude\ArrayRenderer\HTML', function () {
     expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
   });
 
+  it('renders dangerouslySetInnerHTML via a special Fragment component name', function () {
+    $html = ['$', 'article', null, [
+      ['$', 'Fragment', ['dangerouslySetInnerHTML' => ['__html' => '<h1>Raw Title</h1><p>Raw paragraph.</p>']]],
+    ]];
+
+    $expected = '<article><h1>Raw Title</h1><p>Raw paragraph.</p></article>';
+
+    expect((new Renderer)($html))->toBe($expected);
+  });
+
+  it('renders dangerouslySetInnerHTML in a Closure component', function () {
+    $Button = fn(array $props) => ['$', 'button', [
+      'type' => 'button',
+      'class' => 'btn',
+      'dangerouslySetInnerHTML' => ['__html' => '<strong>Save</strong>'],
+    ]];
+
+    $html = ['$', $Button];
+
+    $expected = '<button type="button" class="btn"><strong>Save</strong></button>';
+
+    expect((new Renderer)($html))->toBe($expected);
+  });
+
+  it('throws when Fragment receives both dangerouslySetInnerHTML and children', function () {
+    $html = ['$', 'Fragment', ['dangerouslySetInnerHTML' => ['__html' => '<b>raw</b>']], 'child text'];
+
+    expect(fn() => (new Renderer)($html))->toThrow(\Exception::class);
+  });
+
   it('handles nested fragments', function () {
     $html = ['$', 'div', ['class' => 'container'], [
       [


### PR DESCRIPTION
Pull request improves `dangerouslySetInnerHTML` handling in `Renderer` class, adds tests.

**Enhancements to dangerouslySetInnerHTML handling:**

* Validation and retrieval logic for `dangerouslySetInnerHTML` extracted into `resolveDangerouslySetInnerHTML`.
* Main rendering logic updated to use `resolveDangerouslySetInnerHTML` for improved code reuse and reliability.

**Support for Fragment component:**

* Added support for rendering raw HTML in Fragment component.

**Testing improvements:**

* Added tests for `dangerouslySetInnerHTML` rendering and error handling.