### PR TITLE
fix(Renderer): Change 'Fragment' to 'fragment'

### DIFF
--- a/src/renderer/Renderer.php
+++ b/src/renderer/Renderer.php
@@ -113,7 +113,7 @@ final class Renderer {
       return $this->renderNode($this->callComponent($component, $props), $nesting);
     }
 
-    if ($type === 'Fragment') {
+    if ($type === 'fragment') {
       if (array_key_exists('dangerouslySetInnerHTML', $props)) {
         return $this->resolveDangerouslySetInnerHTML($props);
       }

--- a/tests/renderer/Renderer.spec.php
+++ b/tests/renderer/Renderer.spec.php
@@ -315,9 +315,9 @@ describe('Attitude\ArrayRenderer\HTML', function () {
     expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
   });
 
-  it('renders dangerouslySetInnerHTML via a special Fragment component name', function () {
+  it('renders dangerouslySetInnerHTML via a special fragment component name', function () {
     $html = ['$', 'article', null, [
-      ['$', 'Fragment', ['dangerouslySetInnerHTML' => ['__html' => '<h1>Raw Title</h1><p>Raw paragraph.</p>']]],
+      ['$', 'fragment', ['dangerouslySetInnerHTML' => ['__html' => '<h1>Raw Title</h1><p>Raw paragraph.</p>']]],
     ]];
 
     $expected = '<article><h1>Raw Title</h1><p>Raw paragraph.</p></article>';
@@ -339,8 +339,8 @@ describe('Attitude\ArrayRenderer\HTML', function () {
     expect((new Renderer)($html))->toBe($expected);
   });
 
-  it('throws when Fragment receives both dangerouslySetInnerHTML and children', function () {
-    $html = ['$', 'Fragment', ['dangerouslySetInnerHTML' => ['__html' => '<b>raw</b>']], 'child text'];
+  it('throws when fragment receives both dangerouslySetInnerHTML and children', function () {
+    $html = ['$', 'fragment', ['dangerouslySetInnerHTML' => ['__html' => '<b>raw</b>']], 'child text'];
 
     expect(fn() => (new Renderer)($html))->toThrow(\InvalidArgumentException::class);
   });


### PR DESCRIPTION
This pull request standardizes the component name for fragments in the renderer from `’Fragment’` (capitalized) to `’fragment’` (lowercase).

Component name standardization:

* Updated the fragment component check in `Renderer.php` to use `'fragment'` instead of `'Fragment'`, aligning with a lowercase convention.

Test updates for consistency:

* Modified tests in `Renderer.spec.php` to use lowercase ‘fragment’.