### PR TITLE
feat(Compiler): Uppercase components

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,16 @@ echo $renderer(true);        // (empty)
 
 #### Components
 
+**Uppercase tag names are compiled to variable references.**
+
+`formatElement()` outputs `$Component` (a PHP variable reference) for uppercase tag names instead of the string `'Component'`. This means `<Greeting />` compiles to `['$', $Greeting, ...]` rather than `['$', 'Greeting', ...]`, so the renderer's **components map is bypassed** — a `$Greeting` closure must be in scope at evaluation time instead.
+
+> If you relied on passing components via the named map, this is a breaking change.
+
 Pass an associative array of named components as closures. Each component receives a `$props` array (including `children`):
 
 ```php
-$node = ['$', 'Greeting', ['name' => 'World']];
+$node = ['$', $Greeting, ['name' => 'World']];
 
 echo $renderer($node, [
     'Greeting' => function(array $props): array {

--- a/src/compiler/Formatter.php
+++ b/src/compiler/Formatter.php
@@ -7,10 +7,10 @@ require_once 'FormatterInterface.php';
 final class Formatter implements FormatterInterface {
   public function formatElement(string $type, string|null $config, string|null $children): string {
     $compiled = [
-        "'$'",
-        "'{$type}'",
-        $config,
-        $children,
+      "'$'",
+      ctype_upper($type[0]) ? "\${$type}" : "'{$type}'",
+      $config,
+      $children,
     ];
 
     if (empty($compiled[3]) || $compiled[3] === 'null' || $compiled[3] === '[]') {
@@ -23,7 +23,7 @@ final class Formatter implements FormatterInterface {
       $compiled[2] = 'null';
     }
 
-    return '['.implode(', ', $compiled).']';
+    return '[' . implode(', ', $compiled) . ']';
   }
 
   public function formatFragment(string $children): string {

--- a/src/compiler/PragmaFormatter.php
+++ b/src/compiler/PragmaFormatter.php
@@ -8,14 +8,15 @@ final class PragmaFormatter implements FormatterInterface {
   public function __construct(
     private string $pragma = 'html',
     private string $fragment = 'fragment',
-  ) {}
+  ) {
+  }
 
   public function formatElement(string $type, string|null $config, string|null $children): string {
     $compiled = [
-			"'{$type}'",
-			$config,
-			$children,
-		];
+      ctype_upper($type[0]) ? "\${$type}" : "'{$type}'",
+      $config,
+      $children,
+    ];
 
     if (empty($compiled[2]) || $compiled[2] === 'null' || $compiled[2] === '[]') {
       array_pop($compiled);
@@ -27,11 +28,11 @@ final class PragmaFormatter implements FormatterInterface {
       $compiled[1] = 'null';
     }
 
-    return $this->pragma.'('.implode(', ', $compiled).')';
+    return $this->pragma . '(' . implode(', ', $compiled) . ')';
   }
 
   public function formatFragment(string $children): string {
-    return $this->fragment.'('.$children.')';
+    return $this->fragment . '(' . $children . ')';
   }
 
   public function formatAttributeExpression(string $name, string $value): string {

--- a/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_a_simple_uppercase_component_as_a_variable_reference.snap
+++ b/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_a_simple_uppercase_component_as_a_variable_reference.snap
@@ -1,0 +1,17 @@
+[
+    {
+        "$$type": "PHPXElement",
+        "openingElement": [
+            "L1:P0-1:<:60",
+            "L1:P1-7:Button:262:<T_STRING"
+        ],
+        "selfClosing": true,
+        "attributes": [
+            "L1:P7-8: :396:<T_WHITESPACE"
+        ],
+        "closingElement": [
+            "L1:P8-9:\/:47",
+            "L1:P9-10:>:62"
+        ]
+    }
+]

--- a/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_a_simple_uppercase_component_as_a_variable_reference__2.snap
+++ b/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_a_simple_uppercase_component_as_a_variable_reference__2.snap
@@ -1,0 +1,17 @@
+[
+    {
+        "$$type": "PHPXElement",
+        "openingElement": [
+            "L1:P0-1:<:60",
+            "L1:P1-7:Button:262:<T_STRING"
+        ],
+        "selfClosing": true,
+        "attributes": [
+            "L1:P7-8: :396:<T_WHITESPACE"
+        ],
+        "closingElement": [
+            "L1:P8-9:\/:47",
+            "L1:P9-10:>:62"
+        ]
+    }
+]

--- a/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_an_uppercase_component_with_props_and_children.snap
+++ b/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_an_uppercase_component_with_props_and_children.snap
@@ -1,0 +1,36 @@
+[
+    {
+        "$$type": "PHPXElement",
+        "openingElement": [
+            "L1:P0-1:<:60",
+            "L1:P1-7:Button:262:<T_STRING",
+            "L1:P21-22:>:62"
+        ],
+        "selfClosing": false,
+        "attributes": [
+            "L1:P7-8: :396:<T_WHITESPACE",
+            {
+                "$$type": "PHPXAttribute",
+                "name": [
+                    "L1:P8-12:type:262:<T_STRING"
+                ],
+                "assignment": "L1:P12-13:=:61",
+                "value": "L1:P13-21:\"submit\":269:<T_CONSTANT_ENCAPSED_STRING"
+            }
+        ],
+        "children": [
+            {
+                "$$type": "PHPXText",
+                "tokens": [
+                    "L1:P22-28:Submit:262:<T_STRING"
+                ]
+            }
+        ],
+        "closingElement": [
+            "L1:P28-29:<:60",
+            "L1:P29-30:\/:47",
+            "L1:P30-36:Button:262:<T_STRING",
+            "L1:P36-37:>:62"
+        ]
+    }
+]

--- a/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_an_uppercase_component_with_props_and_children__2.snap
+++ b/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_an_uppercase_component_with_props_and_children__2.snap
@@ -1,0 +1,36 @@
+[
+    {
+        "$$type": "PHPXElement",
+        "openingElement": [
+            "L1:P0-1:<:60",
+            "L1:P1-7:Button:262:<T_STRING",
+            "L1:P21-22:>:62"
+        ],
+        "selfClosing": false,
+        "attributes": [
+            "L1:P7-8: :396:<T_WHITESPACE",
+            {
+                "$$type": "PHPXAttribute",
+                "name": [
+                    "L1:P8-12:type:262:<T_STRING"
+                ],
+                "assignment": "L1:P12-13:=:61",
+                "value": "L1:P13-21:\"submit\":269:<T_CONSTANT_ENCAPSED_STRING"
+            }
+        ],
+        "children": [
+            {
+                "$$type": "PHPXText",
+                "tokens": [
+                    "L1:P22-28:Submit:262:<T_STRING"
+                ]
+            }
+        ],
+        "closingElement": [
+            "L1:P28-29:<:60",
+            "L1:P29-30:\/:47",
+            "L1:P30-36:Button:262:<T_STRING",
+            "L1:P36-37:>:62"
+        ]
+    }
+]

--- a/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_mixed_uppercase_and_lowercase_elements.snap
+++ b/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_mixed_uppercase_and_lowercase_elements.snap
@@ -1,0 +1,63 @@
+[
+    {
+        "$$type": "PHPXElement",
+        "openingElement": [
+            "L1:P0-1:<:60",
+            "L1:P1-4:div:262:<T_STRING",
+            "L1:P4-5:>:62"
+        ],
+        "selfClosing": false,
+        "attributes": [],
+        "children": [
+            {
+                "$$type": "PHPXElement",
+                "openingElement": [
+                    "L1:P5-6:<:60",
+                    "L1:P6-12:Button:262:<T_STRING",
+                    "L1:P35-36:>:62"
+                ],
+                "selfClosing": false,
+                "attributes": [
+                    "L1:P12-13: :396:<T_WHITESPACE",
+                    {
+                        "$$type": "PHPXAttribute",
+                        "name": [
+                            "L1:P13-20:onClick:262:<T_STRING"
+                        ],
+                        "assignment": "L1:P20-21:=:61",
+                        "value": {
+                            "$$type": "Block",
+                            "opening": "L1:P21-22:{:123",
+                            "children": [
+                                "L1:P22-34:$handleClick:266:<T_VARIABLE"
+                            ],
+                            "closing": "L1:P34-35:}:125"
+                        }
+                    }
+                ],
+                "children": [
+                    {
+                        "$$type": "PHPXText",
+                        "tokens": [
+                            "L1:P36-41:Click:262:<T_STRING",
+                            "L1:P41-42: :396:<T_WHITESPACE",
+                            "L1:P42-44:me:262:<T_STRING"
+                        ]
+                    }
+                ],
+                "closingElement": [
+                    "L1:P44-45:<:60",
+                    "L1:P45-46:\/:47",
+                    "L1:P46-52:Button:262:<T_STRING",
+                    "L1:P52-53:>:62"
+                ]
+            }
+        ],
+        "closingElement": [
+            "L1:P53-54:<:60",
+            "L1:P54-55:\/:47",
+            "L1:P55-58:div:262:<T_STRING",
+            "L1:P58-59:>:62"
+        ]
+    }
+]

--- a/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_mixed_uppercase_and_lowercase_elements__2.snap
+++ b/tests/.pest/snapshots/compiler/Compiler.spec/_compile__→_it_compiles_mixed_uppercase_and_lowercase_elements__2.snap
@@ -1,0 +1,63 @@
+[
+    {
+        "$$type": "PHPXElement",
+        "openingElement": [
+            "L1:P0-1:<:60",
+            "L1:P1-4:div:262:<T_STRING",
+            "L1:P4-5:>:62"
+        ],
+        "selfClosing": false,
+        "attributes": [],
+        "children": [
+            {
+                "$$type": "PHPXElement",
+                "openingElement": [
+                    "L1:P5-6:<:60",
+                    "L1:P6-12:Button:262:<T_STRING",
+                    "L1:P35-36:>:62"
+                ],
+                "selfClosing": false,
+                "attributes": [
+                    "L1:P12-13: :396:<T_WHITESPACE",
+                    {
+                        "$$type": "PHPXAttribute",
+                        "name": [
+                            "L1:P13-20:onClick:262:<T_STRING"
+                        ],
+                        "assignment": "L1:P20-21:=:61",
+                        "value": {
+                            "$$type": "Block",
+                            "opening": "L1:P21-22:{:123",
+                            "children": [
+                                "L1:P22-34:$handleClick:266:<T_VARIABLE"
+                            ],
+                            "closing": "L1:P34-35:}:125"
+                        }
+                    }
+                ],
+                "children": [
+                    {
+                        "$$type": "PHPXText",
+                        "tokens": [
+                            "L1:P36-41:Click:262:<T_STRING",
+                            "L1:P41-42: :396:<T_WHITESPACE",
+                            "L1:P42-44:me:262:<T_STRING"
+                        ]
+                    }
+                ],
+                "closingElement": [
+                    "L1:P44-45:<:60",
+                    "L1:P45-46:\/:47",
+                    "L1:P46-52:Button:262:<T_STRING",
+                    "L1:P52-53:>:62"
+                ]
+            }
+        ],
+        "closingElement": [
+            "L1:P53-54:<:60",
+            "L1:P54-55:\/:47",
+            "L1:P55-58:div:262:<T_STRING",
+            "L1:P58-59:>:62"
+        ]
+    }
+]

--- a/tests/compiler/Compiler.spec.php
+++ b/tests/compiler/Compiler.spec.php
@@ -802,6 +802,66 @@ PHP
     );
   });
 
+  it('compiles a simple uppercase component as a variable reference', function () {
+    $defaultCompiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
+    $defaultCompiler->compile('<Button />');
+    expect($defaultCompiler->getAST())->toMatchSnapshot();
+    expect($defaultCompiler->getCompiled())->toBe(
+      "['$', \$Button]"
+    );
+
+    $pragmaCompiler = newCompiler(
+      withLogger: false,
+      parser: newParser(withLogger: false),
+      formatter: newPragmaFormatter(),
+    );
+    $pragmaCompiler->compile('<Button />');
+    expect($pragmaCompiler->getAST())->toMatchSnapshot();
+    expect($pragmaCompiler->getCompiled())->toBe(
+      "html(\$Button)"
+    );
+  });
+
+  it('compiles an uppercase component with props and children', function () {
+    $defaultCompiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
+    $defaultCompiler->compile('<Button type="submit">Submit</Button>');
+    expect($defaultCompiler->getAST())->toMatchSnapshot();
+    expect($defaultCompiler->getCompiled())->toBe(
+      "['$', \$Button, ['type'=>\"submit\"], ['Submit']]"
+    );
+
+    $pragmaCompiler = newCompiler(
+      withLogger: false,
+      parser: newParser(withLogger: false),
+      formatter: newPragmaFormatter(),
+    );
+    $pragmaCompiler->compile('<Button type="submit">Submit</Button>');
+    expect($pragmaCompiler->getAST())->toMatchSnapshot();
+    expect($pragmaCompiler->getCompiled())->toBe(
+      "html(\$Button, ['type'=>\"submit\"], ['Submit'])"
+    );
+  });
+
+  it('compiles mixed uppercase and lowercase elements', function () {
+    $defaultCompiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
+    $defaultCompiler->compile('<div><Button onClick={$handleClick}>Click me</Button></div>');
+    expect($defaultCompiler->getAST())->toMatchSnapshot();
+    expect($defaultCompiler->getCompiled())->toBe(
+      "['$', 'div', null, [['$', \$Button, ['onClick'=>(\$handleClick)], ['Click me']]]]"
+    );
+
+    $pragmaCompiler = newCompiler(
+      withLogger: false,
+      parser: newParser(withLogger: false),
+      formatter: newPragmaFormatter(),
+    );
+    $pragmaCompiler->compile('<div><Button onClick={$handleClick}>Click me</Button></div>');
+    expect($pragmaCompiler->getAST())->toMatchSnapshot();
+    expect($pragmaCompiler->getCompiled())->toBe(
+      "html('div', null, [html(\$Button, ['onClick'=>(\$handleClick)], ['Click me'])])"
+    );
+  });
+
   it('throws an error when a using PHP opening tags', function () {
     $defaultCompiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
     expect(fn() => $defaultCompiler->compile('<title>[<?=$todayFormatted?>]</title>'))->toThrow(\ParseError::class, 'Unexpected PHP opening tag on line 1');


### PR DESCRIPTION
Breaking change in PHPX compiler: uppercase component tag names (e.g., `<Button />`) are now compiled to PHP variable references (e.g., `$Button`), bypassing the renderer’s components map.

**Component Compilation Logic:**

- Updated `formatElement()` to output PHP variable references for uppercase tag names.

**Documentation:**

- README.md updated to document breaking change regarding uppercase tag names.

**Testing:**

- Tests added and updated in `Compiler.spec.php` to verify uppercase component compilation.
- Snapshot files updated to reflect new AST and compiled output.