### PR TITLE
fix(Parser): Handle truncated and malformed tags gracefully

### DIFF
--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -121,7 +121,9 @@ final class Parser {
 			if ($closingElementEnd === null) {
 				throw new \ParseError("Unexpected end of input, expected '>' for closing tag '</{$elementNameText}>' from line {$elementLine}");
 			}
-			assert($closingElementEnd->id === TX_ELEMENT_CLOSING_CLOSE);
+			if ($closingElementEnd->id !== TX_ELEMENT_CLOSING_CLOSE) {
+				throw new \ParseError("Unexpected token '{$closingElementEnd->text}' in closing tag '</{$elementNameText}>', expected '>' at line {$closingElementEnd->line}");
+			}
 
 			return [
 				'$$type' => NodeType::PHPX_ELEMENT,
@@ -135,12 +137,23 @@ final class Parser {
 			];
 		}
 
+		if (!$this->tokens->exist()) {
+			$elementNameText = is_array($elementName)
+				? implode('', array_map(fn(Token $t) => $t->text, $elementName))
+				: $elementName->text;
+			$elementLine = is_array($elementName) ? $elementName[0]->line : $elementName->line;
+			throw new \ParseError("Unexpected end of input, expected '>' or '/>' for '<{$elementNameText}>' from line {$elementLine}");
+		}
+
 		throw new \ParseError("Not implemented");
 	}
 
 	protected function parseElementName(): Token|array {
 		$this->debugCurrentToken(__FUNCTION__);
 		$firstToken = $this->tokens->tokenAtCursorAndForward();
+		if ($firstToken === null) {
+			throw new \ParseError("Unexpected end of input, expected element name");
+		}
 		assert($firstToken->id === T_STRING);
 
 		if (!$this->tokens->tokenAtCursorMatches('-') || !$this->tokens->tokenAtCursorIsWord(1)) {
@@ -419,7 +432,11 @@ final class Parser {
 	}
 
 	protected function unexpectedTokenMessage(?string $expected = null): string {
-		return "Unexpected token #{$this->tokens->index()} => {$this->tokens->tokenAtCursor()} at line {$this->tokens->tokenAtCursor()->line}" . (
+		$token = $this->tokens->tokenAtCursor();
+		if ($token === null) {
+			return "Unexpected end of input" . ($expected ? ", expected {$expected}" : '');
+		}
+		return "Unexpected token #{$this->tokens->index()} => {$token} at line {$token->line}" . (
 			$expected ? ", expected {$expected} instead" : ''
 		);
 	}

--- a/src/parser/TokensList.php
+++ b/src/parser/TokensList.php
@@ -71,9 +71,11 @@ final class TokensList implements \JsonSerializable, \Iterator {
 	public function tokenAtCursorIsWord(int $offset = 0): Token|null {
 		$token = $this->tokenAtCursor($offset);
 
-		if ($token?->id === T_STRING) {
+		if ($token === null) {
+			return null;
+		} else if ($token->id === T_STRING) {
 			return $token;
-		} else if (preg_match('/^\w+$/', $token?->text)) {
+		} else if (preg_match('/^\w+$/', $token->text)) {
 			return $token;
 		} else {
 			return null;

--- a/tests/compiler/Compiler.spec.php
+++ b/tests/compiler/Compiler.spec.php
@@ -1004,4 +1004,34 @@ describe('unexpected end of input', function () {
     expect(fn() => $compiler->compile('[$a'))
       ->toThrow(\ParseError::class, "expected closing ']'");
   });
+
+  it('throws ParseError for truncated opening tag with no element name', function () {
+    $compiler = newCompiler(parser: newParser());
+    expect(fn() => $compiler->compile('<'))
+      ->toThrow(\ParseError::class, "expected element name");
+  });
+
+  it('throws ParseError for truncated opening tag missing closing bracket', function () {
+    $compiler = newCompiler(parser: newParser());
+    expect(fn() => $compiler->compile('<div'))
+      ->toThrow(\ParseError::class, "expected '>' or '/>' for '<div>'");
+  });
+
+  it('throws ParseError for truncated attribute without value', function () {
+    $compiler = newCompiler(parser: newParser());
+    expect(fn() => $compiler->compile('<div attr'))
+      ->toThrow(\ParseError::class, 'expected "=" (attribute assignment)');
+  });
+
+  it('throws ParseError for truncated closing tag with no name', function () {
+    $compiler = newCompiler(parser: newParser());
+    expect(fn() => $compiler->compile('<div></'))
+      ->toThrow(\ParseError::class, "expected closing tag for '<div>'");
+  });
+
+  it('throws ParseError for unexpected token in closing tag', function () {
+    $compiler = newCompiler(parser: newParser());
+    expect(fn() => $compiler->compile('<div></div attr'))
+      ->toThrow(\ParseError::class, "expected '>'");
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #18. The parser crashed or produced unhelpful errors on various malformed/truncated inputs. This PR systematically hardens all tag-parsing code paths against unexpected end-of-input and malformed tokens.

## What was broken

| Input | Before | After |
|---|---|---|
| `<` | Null dereference in `parseElementName()` | `ParseError: expected element name` |
| `<div` | Generic `"Not implemented"` | `ParseError: expected '>' or '/>'` |
| `<div attr` | Null dereference in `unexpectedTokenMessage()` | `ParseError: Unexpected end of input, expected "="` |
| `<my-` | `TypeError: preg_match() on null` in `tokenAtCursorIsWord()` | `ParseError: Unexpected token '-'` |
| `<div></div attr` | `AssertionError` on closing element end | `ParseError: expected '>'` |

## Changes

- **`Parser::parseElementName()`** — null check on `tokenAtCursorAndForward()` before accessing `->id`
- **`Parser::parseElement()`** — end-of-input check before the generic `"Not implemented"` fallback
- **`Parser::unexpectedTokenMessage()`** — null-safe: returns `"Unexpected end of input"` when no token at cursor
- **`TokensList::tokenAtCursorIsWord()`** — early return on null token to avoid `preg_match()` on null
- **`Parser::parseElement()` closing tag** — replace `assert` with explicit `ParseError` for non-`>` tokens after closing tag name
- 4 new tests covering truncated/malformed tag error paths