### PR TITLE
chore: Simplify LSP

### DIFF
--- a/src/language-server/CompletionProvider.php
+++ b/src/language-server/CompletionProvider.php
@@ -109,10 +109,13 @@ final class CompletionProvider
 
     private function completeTagName(string $partial): array
     {
+        static $allElements = null;
+        if ($allElements === null) {
+            $allElements = array_unique(array_merge(self::HTML_ELEMENTS, self::VOID_ELEMENTS));
+            sort($allElements);
+        }
+
         $items = [];
-        $allElements = array_merge(self::HTML_ELEMENTS, self::VOID_ELEMENTS);
-        $allElements = array_unique($allElements);
-        sort($allElements);
 
         foreach ($allElements as $tag) {
             if ($partial === '' || str_starts_with($tag, strtolower($partial))) {
@@ -193,49 +196,9 @@ final class CompletionProvider
         return $items;
     }
 
-    /**
-     * Check if the cursor is inside a quoted string ("…" or '…') or a {…}
-     * expression container. Handles backslash-escaped quote characters.
-     * Used to suppress tag-name and close-tag completions when the `<` is
-     * inside attribute string content rather than markup.
-     *
-     * Note: operates on the current-line prefix only. Multi-line attribute values
-     * (a string literal spanning multiple lines) are not detected. In practice
-     * PHPX source files do not use multi-line quoted attribute values, so this
-     * is an acceptable limitation.
-     */
     private function isInsideStringOrExpression(string $prefix): bool
     {
-        $depth = 0;
-        $inDouble = false;
-        $inSingle = false;
-        $inBacktick = false;
-        $len = strlen($prefix);
-
-        for ($i = 0; $i < $len; $i++) {
-            $c = $prefix[$i];
-
-            if ($inDouble) {
-                if ($c === '\\') { $i++; continue; }
-                if ($c === '"') { $inDouble = false; }
-            } elseif ($inSingle) {
-                if ($c === '\\') { $i++; continue; }
-                if ($c === "'") { $inSingle = false; }
-            } elseif ($inBacktick) {
-                if ($c === '\\') { $i++; continue; }
-                if ($c === '`') { $inBacktick = false; }
-            } elseif ($depth === 0) {
-                if ($c === '"') { $inDouble = true; }
-                elseif ($c === "'") { $inSingle = true; }
-                elseif ($c === '`') { $inBacktick = true; }
-                elseif ($c === '{') { $depth++; }
-            } else {
-                if ($c === '{') { $depth++; }
-                elseif ($c === '}') { $depth = max(0, $depth - 1); }
-            }
-        }
-
-        return $depth > 0 || $inDouble || $inSingle || $inBacktick;
+        return TagScanner::isInsideStringOrExpression($prefix);
     }
 
     /**

--- a/src/language-server/DiagnosticsProvider.php
+++ b/src/language-server/DiagnosticsProvider.php
@@ -28,8 +28,6 @@ final class DiagnosticsProvider
             $this->parser->parse($tokensList);
 
             return [];
-        } catch (\ParseError $e) {
-            return [$this->parseErrorToDiagnostic($e, $source)];
         } catch (\Throwable $e) {
             // Catches \Exception, \AssertionError, and any other \Error.
             // The parser uses assert() extensively — when parsing incomplete
@@ -37,23 +35,6 @@ final class DiagnosticsProvider
             // extends \Error, not \Exception.
             return [$this->throwableToDiagnostic($e, $source)];
         }
-    }
-
-    private function parseErrorToDiagnostic(\ParseError $e, string $source): array
-    {
-        $line = max(0, $this->extractLine($e->getMessage()) - 1);
-        $lines = explode("\n", $source);
-        $lineText = $lines[$line] ?? '';
-
-        return [
-            'range' => [
-                'start' => ['line' => $line, 'character' => 0],
-                'end' => ['line' => $line, 'character' => strlen($lineText)],
-            ],
-            'severity' => 1, // DiagnosticSeverity.Error
-            'source' => 'phpx',
-            'message' => $e->getMessage(),
-        ];
     }
 
     private function throwableToDiagnostic(\Throwable $e, string $source): array

--- a/src/language-server/HoverProvider.php
+++ b/src/language-server/HoverProvider.php
@@ -118,7 +118,7 @@ final class HoverProvider
 
     private function isWordChar(string $char): bool
     {
-        return preg_match('/[\w]/', $char) === 1;
+        return ctype_alnum($char) || $char === '_';
     }
 
     /**
@@ -157,48 +157,9 @@ final class HoverProvider
         return null;
     }
 
-    /**
-     * Check if the given line prefix ends inside a quoted string ("…", '…', `…`)
-     * or a {…} expression container. Used to suppress hover results when the
-     * cursor is inside attribute string content rather than markup.
-     *
-     * Note: operates on the current-line prefix only. Multi-line attribute values
-     * (a string literal spanning multiple lines) are not detected. In practice
-     * PHPX source files do not use multi-line quoted attribute values, so this
-     * is an acceptable limitation.
-     */
     private function isInsideStringOrExpression(string $prefix): bool
     {
-        $depth = 0;
-        $inDouble = false;
-        $inSingle = false;
-        $inBacktick = false;
-        $len = strlen($prefix);
-
-        for ($i = 0; $i < $len; $i++) {
-            $c = $prefix[$i];
-
-            if ($inDouble) {
-                if ($c === '\\') { $i++; continue; }
-                if ($c === '"') { $inDouble = false; }
-            } elseif ($inSingle) {
-                if ($c === '\\') { $i++; continue; }
-                if ($c === "'") { $inSingle = false; }
-            } elseif ($inBacktick) {
-                if ($c === '\\') { $i++; continue; }
-                if ($c === '`') { $inBacktick = false; }
-            } elseif ($depth === 0) {
-                if ($c === '"') { $inDouble = true; }
-                elseif ($c === "'") { $inSingle = true; }
-                elseif ($c === '`') { $inBacktick = true; }
-                elseif ($c === '{') { $depth++; }
-            } else {
-                if ($c === '{') { $depth++; }
-                elseif ($c === '}') { $depth = max(0, $depth - 1); }
-            }
-        }
-
-        return $depth > 0 || $inDouble || $inSingle || $inBacktick;
+        return TagScanner::isInsideStringOrExpression($prefix);
     }
 
     private function makeHover(string $content, int $line, int $startChar, int $endChar): array

--- a/src/language-server/RenameProvider.php
+++ b/src/language-server/RenameProvider.php
@@ -48,13 +48,14 @@ final class RenameProvider
             return null;
         }
 
-        $tag = TagScanner::findTagAtPosition($document->text, $line, $character);
+        $tags = TagScanner::scan($document->text);
+        $tag = TagScanner::findTagAtPositionFromTags($tags, $line, $character);
 
         if ($tag === null) {
             return null;
         }
 
-        $pairs = TagScanner::findPairs($document->text);
+        $pairs = TagScanner::findPairsFromTags($tags);
         $edits = [];
 
         // Find the pair containing the cursor

--- a/src/language-server/TagScanner.php
+++ b/src/language-server/TagScanner.php
@@ -191,7 +191,17 @@ final class TagScanner
      */
     public static function findPairs(string $source): array
     {
-        $tags = self::scan($source);
+        return self::findPairsFromTags(self::scan($source));
+    }
+
+    /**
+     * Find matched open/close pairs from a pre-scanned tag list.
+     *
+     * @param  array<int, array{name: string, line: int, start: int, end: int, kind: string}> $tags
+     * @return array<int, array{open: array, close: array|null}>
+     */
+    public static function findPairsFromTags(array $tags): array
+    {
         $stack = [];
         $pairs = [];
 
@@ -249,8 +259,17 @@ final class TagScanner
      */
     public static function findTagAtPosition(string $source, int $line, int $character): ?array
     {
-        $tags = self::scan($source);
+        return self::findTagAtPositionFromTags(self::scan($source), $line, $character);
+    }
 
+    /**
+     * Find the tag at a specific cursor position from a pre-scanned tag list.
+     *
+     * @param  array<int, array{name: string, line: int, start: int, end: int, kind: string}> $tags
+     * @return array{name: string, line: int, start: int, end: int, kind: string}|null
+     */
+    public static function findTagAtPositionFromTags(array $tags, int $line, int $character): ?array
+    {
         foreach ($tags as $tag) {
             if ($tag['line'] === $line && $character >= $tag['start'] && $character < $tag['end']) {
                 return $tag;
@@ -258,5 +277,48 @@ final class TagScanner
         }
 
         return null;
+    }
+
+    /**
+     * Check if the given line prefix ends inside a quoted string ("…", '…', `…`)
+     * or a {…} expression container. Used to suppress completions and hover
+     * results when the cursor is inside attribute string content rather than markup.
+     *
+     * Note: operates on the current-line prefix only. Multi-line attribute values
+     * are not detected. In practice PHPX files do not use multi-line quoted
+     * attribute values, so this is an acceptable limitation.
+     */
+    public static function isInsideStringOrExpression(string $prefix): bool
+    {
+        $depth = 0;
+        $inDouble = false;
+        $inSingle = false;
+        $inBacktick = false;
+        $len = strlen($prefix);
+
+        for ($i = 0; $i < $len; $i++) {
+            $c = $prefix[$i];
+
+            if ($inDouble) {
+                if ($c === '\\') { $i++; continue; }
+                if ($c === '"') { $inDouble = false; }
+            } elseif ($inSingle) {
+                if ($c === '\\') { $i++; continue; }
+                if ($c === "'") { $inSingle = false; }
+            } elseif ($inBacktick) {
+                if ($c === '\\') { $i++; continue; }
+                if ($c === '`') { $inBacktick = false; }
+            } elseif ($depth === 0) {
+                if ($c === '"') { $inDouble = true; }
+                elseif ($c === "'") { $inSingle = true; }
+                elseif ($c === '`') { $inBacktick = true; }
+                elseif ($c === '{') { $depth++; }
+            } else {
+                if ($c === '{') { $depth++; }
+                elseif ($c === '}') { $depth = max(0, $depth - 1); }
+            }
+        }
+
+        return $depth > 0 || $inDouble || $inSingle || $inBacktick;
     }
 }


### PR DESCRIPTION
## Summary

Post-merge cleanup of the LSP server introduced in #21, driven by a code review pass over the new files.

- **Deduplicate `isInsideStringOrExpression`** — the method was copy-pasted identically into both `CompletionProvider` and `HoverProvider`. Moved to `TagScanner` as a `public static` method; both providers now delegate to it.
- **Merge near-identical diagnostic methods** — `parseErrorToDiagnostic(\ParseError)` and `throwableToDiagnostic(\Throwable)` had identical bodies. Since `\ParseError` is a subtype of `\Throwable`, the separate catch branch and method are removed; a single `catch (\Throwable)` covers both.
- **Avoid double tokenization in `RenameProvider::rename()`** — `findTagAtPosition` and `findPairs` were each calling `TagScanner::scan()` (→ `Token::tokenize()`) on the same source string. Added `findPairsFromTags` and `findTagAtPositionFromTags` helpers that accept a pre-scanned tag array; `rename()` now calls `scan()` once and shares the result.
- **Cache element list in `completeTagName()`** — `array_merge + array_unique + sort` over two constants was re-computed on every keystroke. Now computed once via a `static` local variable.
- **Replace regex in `isWordChar()`** — `preg_match('/[\w]/', $char)` called in a per-character loop; replaced with `ctype_alnum($char) || $char === '_'`.

All 440 tests pass.