### PR TITLE
chore: Simplify extension

### DIFF
--- a/extension/src/compiler.ts
+++ b/extension/src/compiler.ts
@@ -14,7 +14,6 @@ export interface CompilationResult {
  */
 export class PHPXCompiler {
 	private outputChannel: vscode.OutputChannel;
-	private compilationErrors: Map<string, string> = new Map();
 	/** Cache: workspace folder fsPath → resolved compiler script path (or null if not found) */
 	private compilerScriptCache: Map<string, string | null> = new Map();
 	/** Cache: workspace folder fsPath → resolved project root */
@@ -178,6 +177,7 @@ export class PHPXCompiler {
 			let stdout = '';
 			let stderr = '';
 			let truncated = false;
+			let stderrOverflow = false;
 
 			proc.stdout!.on('data', (data: Buffer) => {
 				try {
@@ -194,7 +194,7 @@ export class PHPXCompiler {
 					proc.kill();
 				}
 			});
-			let stderrOverflow = false;
+
 			proc.stderr!.on('data', (data: Buffer) => {
 				try {
 					if (stderr.length < maxOutputBytes) {
@@ -218,13 +218,12 @@ export class PHPXCompiler {
 			});
 
 			proc.on('close', (code) => {
-				if (truncated) {
+				if (truncated || stderrOverflow) {
 					resolve({
 						php: '',
 						error: 'Compilation output exceeded size limit',
 					});
 				} else if (code === 0) {
-					this.compilationErrors.delete(documentUri.toString());
 					resolve({ php: stdout });
 				} else {
 					let errorMessage = stderr;
@@ -234,7 +233,6 @@ export class PHPXCompiler {
 					} catch {
 						// stderr is not JSON, use as-is
 					}
-					this.compilationErrors.set(documentUri.toString(), errorMessage);
 					resolve({
 						php: '',
 						error: errorMessage,
@@ -306,20 +304,11 @@ export class PHPXCompiler {
 
 			return { phpUri };
 		} catch (err) {
-			const error =
-				(err instanceof Error
-					? err.message || err.stack || String(err)
-					: String(err)) || 'Unknown compilation error';
-			const errorLog = err instanceof Error ? err.stack || error : error;
+			const message = err instanceof Error ? err.message || String(err) : String(err);
+			const errorLog = err instanceof Error ? err.stack || message : message;
 			this.outputChannel.appendLine(`[PHPX] compileAndWrite error — ${errorLog}`);
-			return { phpUri, error };
+			return { phpUri, error: message || 'Unknown compilation error' };
 		}
 	}
 
-	/**
-	 * Get the last compilation error for a document
-	 */
-	getCompilationError(documentUri: vscode.Uri): string | undefined {
-		return this.compilationErrors.get(documentUri.toString());
-	}
 }

--- a/extension/src/diagnostics.ts
+++ b/extension/src/diagnostics.ts
@@ -60,9 +60,7 @@ export class PHPXDiagnosticsManager {
 			}
 
 			// Forward diagnostics to the PHPX file with remapped positions
-			const forwarded = phpDiagnostics
-				.filter((d) => this.shouldForwardDiagnostic(d))
-				.map((d) => {
+			const forwarded = phpDiagnostics.map((d) => {
 					const mappedRange = mapRangeToPhpx(uri, phpxUri, d.range);
 					const mapped = new vscode.Diagnostic(
 						mappedRange,
@@ -109,15 +107,6 @@ export class PHPXDiagnosticsManager {
 
 			this.diagnosticCollection.set(phpxUri, forwarded);
 		}
-	}
-
-	/**
-	 * Filter out diagnostics that are artifacts of the PHPX→PHP compilation.
-	 */
-	private shouldForwardDiagnostic(diagnostic: vscode.Diagnostic): boolean {
-		// Forward all diagnostics for now.
-		// Can be refined later to filter out compilation artifacts.
-		return true;
 	}
 
 	/**

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -168,9 +168,10 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Invalidate caches when vendor/composer files change
 	const vendorWatcher = vscode.workspace.createFileSystemWatcher('**/vendor/autoload.php');
-	vendorWatcher.onDidCreate(() => compiler.clearCache());
-	vendorWatcher.onDidChange(() => compiler.clearCache());
-	vendorWatcher.onDidDelete(() => compiler.clearCache());
+	const clearCompilerCache = () => compiler.clearCache();
+	vendorWatcher.onDidCreate(clearCompilerCache);
+	vendorWatcher.onDidChange(clearCompilerCache);
+	vendorWatcher.onDidDelete(clearCompilerCache);
 	context.subscriptions.push(vendorWatcher);
 
 	// Clean up when a PHPX file is closed

--- a/extension/src/languageClient.ts
+++ b/extension/src/languageClient.ts
@@ -38,8 +38,7 @@ export function startLanguageClient(
 
 	outputChannel.appendLine(`[PHPX LSP] Using server script: ${serverScript}`);
 
-	const cwd =
-		vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? undefined;
+	const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
 	const serverOptions: ServerOptions = {
 		command: phpPath,

--- a/extension/src/positionMapper.ts
+++ b/extension/src/positionMapper.ts
@@ -17,7 +17,7 @@ import * as vscode from 'vscode';
  * PHP identifier pattern: variable ($name) or identifier (name).
  * Matches the same tokens the PHP language server would consider "words".
  */
-const PHP_WORD_PATTERN = /\$?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*/g;
+const PHP_WORD_PATTERN = /\$?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*/;
 
 /**
  * File content cache with mtime validation.
@@ -85,8 +85,8 @@ function getFileContent(uri: vscode.Uri): string | null {
 
 	// 3. Read from disk and cache
 	try {
-		const content = fs.readFileSync(fsPath, 'utf-8');
 		const stat = fs.statSync(fsPath);
+		const content = fs.readFileSync(fsPath, 'utf-8');
 		fileCache.set(fsPath, { content, mtime: stat.mtimeMs });
 		return content;
 	} catch {

--- a/extension/src/positionMapper.ts
+++ b/extension/src/positionMapper.ts
@@ -247,7 +247,7 @@ function getWordAt(
 	line: string,
 	charOffset: number,
 ): { text: string; start: number } | null {
-	const matches = [...line.matchAll(PHP_WORD_PATTERN)];
+	const matches = [...line.matchAll(new RegExp(PHP_WORD_PATTERN.source, 'g'))];
 	for (const match of matches) {
 		const start = match.index!;
 		const end = start + match[0].length;

--- a/extension/src/providers.ts
+++ b/extension/src/providers.ts
@@ -46,69 +46,73 @@ function mapLocationLinkToSource(
 	phpxUri: vscode.Uri,
 	phpUri: vscode.Uri,
 ): vscode.LocationLink {
-	let targetUri = link.targetUri;
-	let targetRange = link.targetRange;
-	let targetSelectionRange = link.targetSelectionRange;
-
-	if (targetUri.fsPath === phpUri.fsPath) {
-		targetRange = mapRangeToPhpx(phpUri, phpxUri, link.targetRange);
-		targetSelectionRange = link.targetSelectionRange
-			? mapRangeToPhpx(phpUri, phpxUri, link.targetSelectionRange)
-			: undefined;
-		targetUri = phpxUri;
-	} else if (PHPXCompiler.hasPhpxSource(targetUri)) {
-		const sourceUri = PHPXCompiler.getSourceUri(targetUri);
-		targetRange = mapRangeToPhpx(targetUri, sourceUri, link.targetRange);
-		targetSelectionRange = link.targetSelectionRange
-			? mapRangeToPhpx(targetUri, sourceUri, link.targetSelectionRange)
-			: undefined;
-		targetUri = sourceUri;
+	let remapUri: vscode.Uri | undefined;
+	if (link.targetUri.fsPath === phpUri.fsPath) {
+		remapUri = phpxUri;
+	} else if (PHPXCompiler.hasPhpxSource(link.targetUri)) {
+		remapUri = PHPXCompiler.getSourceUri(link.targetUri);
 	}
+
 	return {
 		originSelectionRange: link.originSelectionRange
 			? mapRangeToPhpx(phpUri, phpxUri, link.originSelectionRange)
 			: undefined,
-		targetUri,
-		targetRange,
-		targetSelectionRange,
+		targetUri: remapUri ?? link.targetUri,
+		targetRange: remapUri
+			? mapRangeToPhpx(link.targetUri, remapUri, link.targetRange)
+			: link.targetRange,
+		targetSelectionRange: remapUri && link.targetSelectionRange
+			? mapRangeToPhpx(link.targetUri, remapUri, link.targetSelectionRange)
+			: link.targetSelectionRange,
 	};
 }
 
 // ─── Completion and Hover are handled by the PHPX Language Server (LSP) ─────
 
+/**
+ * Delegate a location-style command to the compiled PHP file and remap results back to PHPX.
+ * Shared by Definition, TypeDefinition, and Implementation providers.
+ */
+async function delegateLocationProvider(
+	document: vscode.TextDocument,
+	position: vscode.Position,
+	command: string,
+): Promise<vscode.Definition | vscode.LocationLink[] | null> {
+	const phpUri = PHPXCompiler.getCompiledUri(document.uri);
+	const phpxUri = document.uri;
+	const mappedPosition = mapPositionToPhp(document, position, phpUri);
+
+	try {
+		const result = await vscode.commands.executeCommand<
+			(vscode.Location | vscode.LocationLink)[]
+		>(command, phpUri, mappedPosition);
+
+		if (!result || result.length === 0) {
+			return null;
+		}
+
+		if ('targetUri' in result[0]) {
+			return (result as vscode.LocationLink[]).map((item) =>
+				mapLocationLinkToSource(item, phpxUri, phpUri),
+			);
+		}
+		return (result as vscode.Location[]).map((item) =>
+			mapLocationToSource(item, phpxUri, phpUri),
+		);
+	} catch {
+		return null;
+	}
+}
+
 // ─── Definition ──────────────────────────────────────────────────────────────
 
 export class PHPXDefinitionProvider implements vscode.DefinitionProvider {
-	async provideDefinition(
+	provideDefinition(
 		document: vscode.TextDocument,
 		position: vscode.Position,
 		_token: vscode.CancellationToken,
 	): Promise<vscode.Definition | vscode.LocationLink[] | null> {
-		const phpUri = PHPXCompiler.getCompiledUri(document.uri);
-		const phpxUri = document.uri;
-		const mappedPosition = mapPositionToPhp(document, position, phpUri);
-
-		try {
-			const result = await vscode.commands.executeCommand<
-				(vscode.Location | vscode.LocationLink)[]
-			>('vscode.executeDefinitionProvider', phpUri, mappedPosition);
-
-			if (!result || result.length === 0) {
-				return null;
-			}
-
-			// Separate into typed arrays to satisfy the union return type
-			if ('targetUri' in result[0]) {
-				return (result as vscode.LocationLink[]).map((item) =>
-					mapLocationLinkToSource(item, phpxUri, phpUri),
-				);
-			}
-			return (result as vscode.Location[]).map((item) =>
-				mapLocationToSource(item, phpxUri, phpUri),
-			);
-		} catch {
-			return null;
-		}
+		return delegateLocationProvider(document, position, 'vscode.executeDefinitionProvider');
 	}
 }
 
@@ -117,35 +121,12 @@ export class PHPXDefinitionProvider implements vscode.DefinitionProvider {
 export class PHPXTypeDefinitionProvider
 	implements vscode.TypeDefinitionProvider
 {
-	async provideTypeDefinition(
+	provideTypeDefinition(
 		document: vscode.TextDocument,
 		position: vscode.Position,
 		_token: vscode.CancellationToken,
 	): Promise<vscode.Definition | vscode.LocationLink[] | null> {
-		const phpUri = PHPXCompiler.getCompiledUri(document.uri);
-		const phpxUri = document.uri;
-		const mappedPosition = mapPositionToPhp(document, position, phpUri);
-
-		try {
-			const result = await vscode.commands.executeCommand<
-				(vscode.Location | vscode.LocationLink)[]
-			>('vscode.executeTypeDefinitionProvider', phpUri, mappedPosition);
-
-			if (!result || result.length === 0) {
-				return null;
-			}
-
-			if ('targetUri' in result[0]) {
-				return (result as vscode.LocationLink[]).map((item) =>
-					mapLocationLinkToSource(item, phpxUri, phpUri),
-				);
-			}
-			return (result as vscode.Location[]).map((item) =>
-				mapLocationToSource(item, phpxUri, phpUri),
-			);
-		} catch {
-			return null;
-		}
+		return delegateLocationProvider(document, position, 'vscode.executeTypeDefinitionProvider');
 	}
 }
 
@@ -249,44 +230,6 @@ export class PHPXDocumentSymbolProvider
 					sym.kind,
 					sym.containerName,
 					new vscode.Location(phpxUri, range),
-				);
-			});
-		} catch {
-			return null;
-		}
-	}
-}
-
-// ─── Workspace Symbols ──────────────────────────────────────────────────────
-
-export class PHPXWorkspaceSymbolProvider
-	implements vscode.WorkspaceSymbolProvider
-{
-	async provideWorkspaceSymbols(
-		query: string,
-		_token: vscode.CancellationToken,
-	): Promise<vscode.SymbolInformation[] | null> {
-		try {
-			const result = await vscode.commands.executeCommand<
-				vscode.SymbolInformation[]
-			>('vscode.executeWorkspaceSymbolProvider', query);
-
-			if (!result) {
-				return null;
-			}
-
-			return result.map((symbol) => {
-				const loc = symbol.location;
-				if (!PHPXCompiler.hasPhpxSource(loc.uri)) {
-					return symbol;
-				}
-				const sourceUri = PHPXCompiler.getSourceUri(loc.uri);
-				const range = mapRangeToPhpx(loc.uri, sourceUri, loc.range);
-				return new vscode.SymbolInformation(
-					symbol.name,
-					symbol.kind,
-					symbol.containerName ?? '',
-					new vscode.Location(sourceUri, range),
 				);
 			});
 		} catch {
@@ -455,34 +398,11 @@ export class PHPXRenameProvider implements vscode.RenameProvider {
 export class PHPXImplementationProvider
 	implements vscode.ImplementationProvider
 {
-	async provideImplementation(
+	provideImplementation(
 		document: vscode.TextDocument,
 		position: vscode.Position,
 		_token: vscode.CancellationToken,
 	): Promise<vscode.Definition | vscode.LocationLink[] | null> {
-		const phpUri = PHPXCompiler.getCompiledUri(document.uri);
-		const phpxUri = document.uri;
-		const mappedPosition = mapPositionToPhp(document, position, phpUri);
-
-		try {
-			const result = await vscode.commands.executeCommand<
-				(vscode.Location | vscode.LocationLink)[]
-			>('vscode.executeImplementationProvider', phpUri, mappedPosition);
-
-			if (!result || result.length === 0) {
-				return null;
-			}
-
-			if ('targetUri' in result[0]) {
-				return (result as vscode.LocationLink[]).map((item) =>
-					mapLocationLinkToSource(item, phpxUri, phpUri),
-				);
-			}
-			return (result as vscode.Location[]).map((item) =>
-				mapLocationToSource(item, phpxUri, phpUri),
-			);
-		} catch {
-			return null;
-		}
+		return delegateLocationProvider(document, position, 'vscode.executeImplementationProvider');
 	}
 }

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -1,43 +1,32 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
+import * as vscode from 'vscode';
 
 suite('PHPX Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	test('Extension should be present', () => {
-		assert.ok(vscode.extensions.getExtension('attitude.phpx-language-support'));
-	});
-
-	test('Extension should activate on PHPX file', async () => {
-		const extension = vscode.extensions.getExtension(
-			'attitude.phpx-language-support',
-		);
-		assert.ok(extension);
-
-		// Create a test PHPX document
-		const doc = await vscode.workspace.openTextDocument({
-			language: 'phpx',
-			content: '<div>Hello World</div>',
-		});
-
-		// Wait for extension to activate
+	test('Extension activates without errors', async () => {
+		const extension = vscode.extensions.getExtension('attitude.phpx-language-support');
+		assert.ok(extension, 'Extension must be installed in test host');
 		await extension.activate();
 		assert.ok(extension.isActive);
 	});
 
-	test('PHPX language should be registered', async () => {
+	test('PHPX language is registered', async () => {
 		const languages = await vscode.languages.getLanguages();
 		assert.ok(languages.includes('phpx'));
 	});
 
-	test('PHPX files should be recognized', async () => {
-		// Test that .phpx extension is recognized
-		const doc = await vscode.workspace.openTextDocument({
-			language: 'phpx',
-			content: '<?php declare(strict_types = 1);\nreturn <div>Hello</div>;',
-		});
-
-		assert.strictEqual(doc.languageId, 'phpx');
+	test('.phpx files are auto-detected as phpx language', async () => {
+		const tmpFile = path.join(os.tmpdir(), `phpx-test-${Date.now()}.phpx`);
+		fs.writeFileSync(tmpFile, '<?php return <div>test</div>;');
+		try {
+			const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(tmpFile));
+			assert.strictEqual(doc.languageId, 'phpx');
+		} finally {
+			fs.unlinkSync(tmpFile);
+		}
 	});
 });

--- a/extension/src/test/grammar.test.ts
+++ b/extension/src/test/grammar.test.ts
@@ -1,148 +1,16 @@
 /**
- * Grammar Test Runner
+ * Grammar structure validation.
  *
- * This file tests the TextMate grammar for PHPX using vscode-tmgrammar-test
+ * Tokenization is tested via `pnpm test:grammar` which runs vscode-tmgrammar-test
+ * against the fixture files in src/test/grammar/. That tool actually tokenizes
+ * the grammar and compares scopes — it cannot run inside the VS Code extension host.
  */
 
 import * as path from 'path';
 import * as fs from 'fs';
 import * as assert from 'assert';
 
-interface TokenInfo {
-	text: string;
-	scopes: string[];
-}
-
-// Simple grammar test using VS Code's built-in tokenizer
-export async function runGrammarTests(): Promise<void> {
-	console.log('Running PHPX Grammar Tests...\n');
-
-	const testCases: {
-		input: string;
-		expectedScopes: { text: string; scope: string }[];
-	}[] = [
-		// Fragment tests
-		{
-			input: '<>content</>',
-			expectedScopes: [
-				{ text: '<>', scope: 'punctuation.definition.tag.phpx.fragment.begin' },
-				{ text: '</>', scope: 'punctuation.definition.tag.phpx.fragment.end' },
-			],
-		},
-		// Self-closing element
-		{
-			input: '<br />',
-			expectedScopes: [
-				{ text: '<', scope: 'punctuation.definition.tag.begin.phpx' },
-				{ text: 'br', scope: 'entity.name.tag.phpx' },
-				{ text: '/>', scope: 'punctuation.definition.tag.end.phpx' },
-			],
-		},
-		// Element with attributes
-		{
-			input: '<div className="container">text</div>',
-			expectedScopes: [
-				{ text: '<', scope: 'punctuation.definition.tag.begin.phpx' },
-				{ text: 'div', scope: 'entity.name.tag.phpx' },
-				{ text: 'className', scope: 'entity.other.attribute-name.phpx' },
-				{ text: '"container"', scope: 'string.quoted.double.phpx' },
-			],
-		},
-		// Expression attribute
-		{
-			input: '<img src={$url} />',
-			expectedScopes: [
-				{ text: 'src', scope: 'entity.other.attribute-name.phpx' },
-				{ text: '{', scope: 'punctuation.definition.brace.begin.phpx' },
-				{ text: '}', scope: 'punctuation.definition.brace.end.phpx' },
-			],
-		},
-		// Spread operator
-		{
-			input: '<div {...$props} />',
-			expectedScopes: [
-				{ text: '...', scope: 'keyword.operator.spread.phpx' },
-				{ text: '$props', scope: 'variable.other.php' },
-			],
-		},
-		// Shorthand attribute
-		{
-			input: '<div {$loading} />',
-			expectedScopes: [{ text: '$loading', scope: 'variable.other.php' }],
-		},
-		// PHPX comment
-		{
-			input: '{/* comment */}',
-			expectedScopes: [
-				{ text: '/*', scope: 'punctuation.definition.comment.begin.phpx' },
-				{ text: '*/', scope: 'punctuation.definition.comment.end.phpx' },
-			],
-		},
-		// Template literal
-		{
-			input: '`Hello, ${$name}!`',
-			expectedScopes: [
-				{
-					text: '`',
-					scope: 'punctuation.definition.string.template.begin.phpx',
-				},
-				{
-					text: '${',
-					scope: 'punctuation.definition.interpolation.begin.phpx',
-				},
-				{ text: '}', scope: 'punctuation.definition.interpolation.end.phpx' },
-			],
-		},
-		// Boolean attribute
-		{
-			input: '<input disabled />',
-			expectedScopes: [
-				{ text: 'disabled', scope: 'entity.other.attribute-name.phpx' },
-			],
-		},
-		// Data attribute with kebab-case
-		{
-			input: '<div data-foo-bar={$value} />',
-			expectedScopes: [
-				{ text: 'data-foo-bar', scope: 'entity.other.attribute-name.phpx' },
-			],
-		},
-		// Nested elements
-		{
-			input: '<div><span>text</span></div>',
-			expectedScopes: [
-				{ text: 'div', scope: 'entity.name.tag.phpx' },
-				{ text: 'span', scope: 'entity.name.tag.phpx' },
-			],
-		},
-		// Expression container in children
-		{
-			input: '<p>Hello, {$name}!</p>',
-			expectedScopes: [
-				{ text: '{', scope: 'punctuation.definition.brace.begin.phpx' },
-				{ text: '}', scope: 'punctuation.definition.brace.end.phpx' },
-			],
-		},
-	];
-
-	console.log(`Running ${testCases.length} grammar test cases...\n`);
-
-	let passed = 0;
-	let failed = 0;
-
-	for (const testCase of testCases) {
-		console.log(`Testing: ${testCase.input}`);
-		// Note: Actual tokenization would require loading the grammar
-		// This is a structural test to ensure the grammar file is valid
-		passed++;
-		console.log('  ✓ Structure validated\n');
-	}
-
-	console.log(`\nGrammar Tests Complete: ${passed} passed, ${failed} failed`);
-}
-
-// Validate grammar JSON structure
-export function validateGrammarStructure(): void {
+function validateGrammarStructure(): void {
 	const grammarPath = path.resolve(
 		__dirname,
 		'../../syntaxes/phpx.tmLanguage.json',
@@ -152,38 +20,18 @@ export function validateGrammarStructure(): void {
 	let grammar: any;
 	try {
 		grammar = JSON.parse(grammarContent);
-		console.log('✓ Grammar JSON is valid');
 	} catch (e) {
 		throw new Error(`Invalid grammar JSON: ${e}`);
 	}
 
-	// Validate required fields
 	assert.ok(grammar.name, 'Grammar must have a name');
 	assert.ok(grammar.scopeName, 'Grammar must have a scopeName');
-	assert.ok(grammar.patterns, 'Grammar must have patterns');
-	assert.ok(grammar.repository, 'Grammar must have a repository');
-
-	console.log('✓ Grammar structure is valid');
-	console.log(`  Name: ${grammar.name}`);
-	console.log(`  Scope: ${grammar.scopeName}`);
-	console.log(`  Patterns: ${grammar.patterns.length}`);
-	console.log(
-		`  Repository entries: ${Object.keys(grammar.repository).length}`,
-	);
+	assert.ok(Array.isArray(grammar.patterns) && grammar.patterns.length > 0, 'Grammar must have a non-empty patterns array');
+	assert.ok(grammar.repository && Object.keys(grammar.repository).length > 0, 'Grammar must have a non-empty repository');
 }
 
-// Mocha test suite — registers grammar tests with the test runner
-// (suite/test are globals provided by Mocha; guard against direct Node execution)
-if (typeof suite !== 'undefined') {
-	suite('PHPX Grammar', () => {
-		test('grammar JSON has valid structure', () => {
-			validateGrammarStructure();
-		});
+suite('PHPX Grammar', () => {
+	test('grammar JSON has valid structure', () => {
+		validateGrammarStructure();
 	});
-}
-
-// Run tests if executed directly
-if (require.main === module) {
-	validateGrammarStructure();
-	runGrammarTests();
-}
+});

--- a/extension/src/test/range-remap.test.ts
+++ b/extension/src/test/range-remap.test.ts
@@ -28,12 +28,15 @@ function createFixturePair(rootDir: string, baseName: string) {
 
 	assert.ok(phpxTitleStart >= 0, 'Fixture PHPX line must include $title');
 	assert.ok(phpTitleStart >= 0, 'Fixture PHP line must include $title');
+	assert.notStrictEqual(phpxTitleStart, phpTitleStart, 'Column offsets must differ so remapping is non-trivial');
 
 	return {
 		phpxUri,
 		phpUri,
-		phpxTitleRange: new vscode.Range(1, phpxTitleStart, 1, phpxTitleStart + 6),
-		phpTitleRange: new vscode.Range(1, phpTitleStart, 1, phpTitleStart + 6),
+		phpxTitleStart,
+		phpTitleStart,
+		phpxTitleRange: new vscode.Range(1, phpxTitleStart, 1, phpxTitleStart + '$title'.length),
+		phpTitleRange: new vscode.Range(1, phpTitleStart, 1, phpTitleStart + '$title'.length),
 	};
 }
 
@@ -87,7 +90,11 @@ suite('PHPX Range Remap', () => {
 			assert.strictEqual(forwarded!.length, 1);
 			assert.ok(
 				forwarded![0].range.start.isEqual(phpxTitleRange.start),
-				'Diagnostic start should be remapped to PHPX start position',
+				`Diagnostic start should remap to PHPX column ${phpxTitleRange.start.character}, got ${forwarded![0].range.start.character}`,
+			);
+			assert.ok(
+				forwarded![0].range.end.isEqual(phpxTitleRange.end),
+				`Diagnostic end should remap to PHPX column ${phpxTitleRange.end.character}, got ${forwarded![0].range.end.character}`,
 			);
 			assert.ok(forwarded![0].relatedInformation);
 			assert.strictEqual(forwarded![0].relatedInformation!.length, 1);
@@ -99,7 +106,7 @@ suite('PHPX Range Remap', () => {
 				forwarded![0].relatedInformation![0].location.range.start.isEqual(
 					phpxTitleRange.start,
 				),
-				'Related info start should be remapped to PHPX start position',
+				'Related info start should be remapped to PHPX position',
 			);
 		} finally {
 			(vscode.languages as any).getDiagnostics = originalGetDiagnostics;
@@ -108,7 +115,7 @@ suite('PHPX Range Remap', () => {
 	});
 
 	test('remaps ranges in provideRenameEdits when redirecting compiled URIs', async () => {
-		const { phpxUri, phpUri, phpxTitleRange, phpTitleRange } = createFixturePair(
+		const { phpxUri, phpUri, phpxTitleRange, phpTitleRange, phpTitleStart } = createFixturePair(
 			tempDir,
 			'rename-edits',
 		);
@@ -117,10 +124,19 @@ suite('PHPX Range Remap', () => {
 		const provider = new PHPXRenameProvider();
 		const originalExecuteCommand = vscode.commands.executeCommand;
 
-		(vscode.commands as any).executeCommand = async (command: string) => {
+		let capturedUri: vscode.Uri | undefined;
+		let capturedPosition: vscode.Position | undefined;
+
+		(vscode.commands as any).executeCommand = async (
+			command: string,
+			uri: vscode.Uri,
+			position: vscode.Position,
+		) => {
 			if (command !== 'vscode.executeDocumentRenameProvider') {
 				return undefined;
 			}
+			capturedUri = uri;
+			capturedPosition = position;
 			const edit = new vscode.WorkspaceEdit();
 			edit.replace(phpUri, phpTitleRange, '$renamed');
 			return edit;
@@ -135,18 +151,39 @@ suite('PHPX Range Remap', () => {
 			);
 
 			assert.ok(result, 'Expected WorkspaceEdit result from rename provider');
+
+			// Verify the command was forwarded to the compiled PHP file
+			assert.strictEqual(
+				capturedUri?.toString(),
+				phpUri.toString(),
+				'Command must target the compiled PHP URI, not the PHPX source',
+			);
+			// Verify PHPX→PHP position mapping happened
+			assert.strictEqual(
+				capturedPosition?.character,
+				phpTitleStart,
+				`Forward-mapped column should be PHP column ${phpTitleStart}, got ${capturedPosition?.character}`,
+			);
+
 			const entries = result!.entries();
 			assert.strictEqual(entries.length, 1);
 			assert.strictEqual(entries[0][0].toString(), phpxUri.toString());
 			assert.strictEqual(entries[0][1].length, 1);
-			assert.ok(entries[0][1][0].range.start.isEqual(phpxTitleRange.start));
+			assert.ok(
+				entries[0][1][0].range.start.isEqual(phpxTitleRange.start),
+				`Remapped range start should be PHPX column ${phpxTitleRange.start.character}`,
+			);
+			assert.ok(
+				entries[0][1][0].range.end.isEqual(phpxTitleRange.end),
+				`Remapped range end should be PHPX column ${phpxTitleRange.end.character}`,
+			);
 		} finally {
 			(vscode.commands as any).executeCommand = originalExecuteCommand;
 		}
 	});
 
 	test('remaps prepareRename range from compiled PHP back to PHPX', async () => {
-		const { phpxUri, phpUri, phpxTitleRange, phpTitleRange } = createFixturePair(
+		const { phpxUri, phpUri, phpxTitleRange, phpTitleRange, phpTitleStart } = createFixturePair(
 			tempDir,
 			'prepare-rename',
 		);
@@ -155,14 +192,20 @@ suite('PHPX Range Remap', () => {
 		const provider = new PHPXRenameProvider();
 		const originalExecuteCommand = vscode.commands.executeCommand;
 
-		(vscode.commands as any).executeCommand = async (command: string) => {
+		let capturedUri: vscode.Uri | undefined;
+		let capturedPosition: vscode.Position | undefined;
+
+		(vscode.commands as any).executeCommand = async (
+			command: string,
+			uri: vscode.Uri,
+			position: vscode.Position,
+		) => {
 			if (command !== 'vscode.prepareRename') {
 				return undefined;
 			}
-			return {
-				range: phpTitleRange,
-				placeholder: '$title',
-			};
+			capturedUri = uri;
+			capturedPosition = position;
+			return { range: phpTitleRange, placeholder: '$title' };
 		};
 
 		try {
@@ -173,24 +216,37 @@ suite('PHPX Range Remap', () => {
 			);
 
 			assert.ok(result, 'Expected prepareRename result');
-			assert.ok(!(result instanceof vscode.Range));
-			assert.ok(
-				(result as { range: vscode.Range }).range.start.isEqual(
-					phpxTitleRange.start,
-				),
-				'prepareRename start should be remapped to PHPX start position',
+
+			// Verify forwarded to PHP URI with mapped position
+			assert.strictEqual(
+				capturedUri?.toString(),
+				phpUri.toString(),
+				'prepareRename must target the compiled PHP URI',
 			);
 			assert.strictEqual(
-				(result as { placeholder: string }).placeholder,
-				'$title',
+				capturedPosition?.character,
+				phpTitleStart,
+				`Forward-mapped column should be PHP column ${phpTitleStart}`,
 			);
+
+			assert.ok(!(result instanceof vscode.Range));
+			const { range, placeholder } = result as { range: vscode.Range; placeholder: string };
+			assert.ok(
+				range.start.isEqual(phpxTitleRange.start),
+				`prepareRename start should remap to PHPX column ${phpxTitleRange.start.character}`,
+			);
+			assert.ok(
+				range.end.isEqual(phpxTitleRange.end),
+				`prepareRename end should remap to PHPX column ${phpxTitleRange.end.character}`,
+			);
+			assert.strictEqual(placeholder, '$title');
 		} finally {
 			(vscode.commands as any).executeCommand = originalExecuteCommand;
 		}
 	});
 
 	test('remaps prepareRename when command returns a bare Range', async () => {
-		const { phpxUri, phpxTitleRange, phpTitleRange } = createFixturePair(
+		const { phpxUri, phpUri, phpxTitleRange, phpTitleRange, phpTitleStart } = createFixturePair(
 			tempDir,
 			'prepare-rename-range',
 		);
@@ -199,10 +255,19 @@ suite('PHPX Range Remap', () => {
 		const provider = new PHPXRenameProvider();
 		const originalExecuteCommand = vscode.commands.executeCommand;
 
-		(vscode.commands as any).executeCommand = async (command: string) => {
+		let capturedUri: vscode.Uri | undefined;
+		let capturedPosition: vscode.Position | undefined;
+
+		(vscode.commands as any).executeCommand = async (
+			command: string,
+			uri: vscode.Uri,
+			position: vscode.Position,
+		) => {
 			if (command !== 'vscode.prepareRename') {
 				return undefined;
 			}
+			capturedUri = uri;
+			capturedPosition = position;
 			return phpTitleRange;
 		};
 
@@ -212,8 +277,28 @@ suite('PHPX Range Remap', () => {
 				new vscode.Position(1, phpxTitleRange.start.character + 1),
 				{} as vscode.CancellationToken,
 			);
-			assert.ok(result instanceof vscode.Range);
-			assert.ok((result as vscode.Range).start.isEqual(phpxTitleRange.start));
+
+			// Verify forwarded to PHP URI with mapped position
+			assert.strictEqual(
+				capturedUri?.toString(),
+				phpUri.toString(),
+				'prepareRename must target the compiled PHP URI',
+			);
+			assert.strictEqual(
+				capturedPosition?.character,
+				phpTitleStart,
+				`Forward-mapped column should be PHP column ${phpTitleStart}`,
+			);
+
+			assert.ok(result instanceof vscode.Range, 'Expected bare Range result');
+			assert.ok(
+				(result as vscode.Range).start.isEqual(phpxTitleRange.start),
+				`Bare range start should remap to PHPX column ${phpxTitleRange.start.character}`,
+			);
+			assert.ok(
+				(result as vscode.Range).end.isEqual(phpxTitleRange.end),
+				`Bare range end should remap to PHPX column ${phpxTitleRange.end.character}`,
+			);
 		} finally {
 			(vscode.commands as any).executeCommand = originalExecuteCommand;
 		}


### PR DESCRIPTION
## Summary

### Simplification (`chore: Simplify extension`)
- **`providers.ts`**: Extracted `delegateLocationProvider()` helper shared by `PHPXDefinitionProvider`, `PHPXTypeDefinitionProvider`, and `PHPXImplementationProvider` — eliminated ~60 lines of triplicated boilerplate. Simplified `mapLocationLinkToSource` using a single `remapUri` variable instead of three mutable lets. Removed dead `PHPXWorkspaceSymbolProvider` class (exported but never registered in `extension.ts`).
- **`compiler.ts`**: Moved `stderrOverflow` declaration above its handler (was declared one line after use). Added `stderrOverflow` to the `close` handler's overflow branch — previously only `truncated` was checked, leaving stderr-overflow kills to fall through to `code !== 0` and attempt `JSON.parse` on a truncated buffer. Removed dead `compilationErrors` map and `getCompilationError()` method (written but never read externally). Fixed `err.message || err.stack` order in `compileAndWrite` catch — stack now used for logging, message for user-facing error.
- **`diagnostics.ts`**: Removed `shouldForwardDiagnostic()` stub (always returned `true`) and its no-op `.filter()` call site.
- **`positionMapper.ts`**: Removed `/g` flag from module-level `PHP_WORD_PATTERN` — `document.getWordRangeAtPosition()` throws if passed a global regex (this was silently swallowing the error in all three location providers). Fixed double-`statSync` on cache miss: stat first, then read.
- **`languageClient.ts`**: Removed redundant `?? undefined` from optional-chain expression.
- **`extension.ts`**: Deduplicated the three identical vendorWatcher event handlers into a shared `clearCompilerCache` callback.

### Bug fix (`fix(positionMapper): use fresh regex in getWordAt for matchAll compatibility`)
- `getWordAt` uses `String.matchAll()` which requires a global regex, but `PHP_WORD_PATTERN` no longer has `/g`. Fixed by creating a fresh `new RegExp(PHP_WORD_PATTERN.source, 'g')` at the call site — consistent with the pattern already used in `getNthOccurrence` and `findNthOccurrence`.

### Tests (`test(extension): fix false positives and strengthen assertions`)
- **`extension.test.ts`**: Replaced circular `languageId` test (was forcibly setting `language: 'phpx'` then asserting `languageId === 'phpx'`) with a real auto-detection test that opens a temp `.phpx` file by URI.
- **`grammar.test.ts`**: Removed `runGrammarTests()` — it looped over 12 test cases with `expectedScopes` arrays that were never read; every case unconditionally incremented `passed`. Actual tokenization is covered by `pnpm test:grammar` via `vscode-tmgrammar-test`. Strengthened `validateGrammarStructure` to assert non-empty `patterns` and `repository`.
- **`range-remap.test.ts`**: Fixed `executeCommand` mocks to capture and assert the forwarded PHP URI and PHPX→PHP mapped column — the forward position mapping was previously completely untested. Added end-position assertions to all four tests (only start was previously checked). Added `phpxTitleStart !== phpTitleStart` guard to guarantee the fixture requires non-trivial column remapping.

## Test plan

- [x] TypeScript compilation passes (`pnpm compile` — no errors)
- [x] All 8 integration tests pass (`pnpm test`)
- [x] Grammar tests pass (`pnpm test:grammar`)
- [ ] Go-to-definition, type definition, and find implementation work in `.phpx` files
- [ ] stderr overflow during compilation produces "Compilation output exceeded size limit" instead of a JSON parse error
- [ ] No regression in diagnostics forwarding from PHP language server to `.phpx` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)