### PR TITLE
chore: Improve

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,3 +36,44 @@ jobs:
       - run: composer install --no-interaction --prefer-dist
 
       - run: vendor/bin/pest
+
+  extension-tests:
+    runs-on: ubuntu-latest
+    name: Extension
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.dir }}
+          key: pnpm-${{ hashFiles('extension/pnpm-lock.yaml') }}
+          restore-keys: pnpm-
+
+      - run: pnpm install
+        working-directory: extension
+
+      - name: Build extension
+        run: pnpm bundle
+        working-directory: extension
+
+      - name: Grammar tests
+        run: pnpm test:grammar
+        working-directory: extension
+
+      - name: Integration tests
+        run: xvfb-run -a pnpm test
+        working-directory: extension

--- a/extension/package.json
+++ b/extension/package.json
@@ -109,7 +109,7 @@
     "bundle": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap --minify",
     "bundle:watch": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch",
     "test": "pnpm compile && node ./out/test/runTest.js",
-    "test:grammar": "vscode-tmgrammar-test -g ./syntaxes/phpx.tmLanguage.json './src/test/grammar/phpx.test.phpx' && vscode-tmgrammar-test -g ./syntaxes/phpx.tmLanguage.json -g '/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/php/syntaxes/php.tmLanguage.json' './src/test/grammar/phpx-function.test.phpx'",
+    "test:grammar": "vscode-tmgrammar-test -g ./syntaxes/phpx.tmLanguage.json './src/test/grammar/phpx.test.phpx' && vscode-tmgrammar-test -g ./syntaxes/phpx.tmLanguage.json './src/test/grammar/phpx-function.test.phpx'",
     "lint": "eslint src --ext ts",
     "package": "pnpm bundle && vsce package --no-dependencies --allow-missing-repository"
   },

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -4,6 +4,8 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+const fixturesDir = path.join(__dirname, '../../src/test/fixtures');
+
 suite('PHPX Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
@@ -29,4 +31,25 @@ suite('PHPX Extension Test Suite', () => {
 			fs.unlinkSync(tmpFile);
 		}
 	});
+ 
+ 	test('fixture: page.phpx is detected as phpx language', async () => {
+ 		const doc = await vscode.workspace.openTextDocument(
+ 			vscode.Uri.file(path.join(fixturesDir, 'page.phpx')),
+ 		);
+ 		assert.strictEqual(doc.languageId, 'phpx');
+ 	});
+ 
+ 	test('fixture: html-page-template.phpx is detected as phpx language', async () => {
+ 		const doc = await vscode.workspace.openTextDocument(
+ 			vscode.Uri.file(path.join(fixturesDir, 'html-page-template.phpx')),
+ 		);
+ 		assert.strictEqual(doc.languageId, 'phpx');
+ 	});
+ 
+ 	test('fixture: syntax-samples.phpx is detected as phpx language', async () => {
+ 		const doc = await vscode.workspace.openTextDocument(
+ 			vscode.Uri.file(path.join(fixturesDir, 'syntax-samples.phpx')),
+ 		);
+ 		assert.strictEqual(doc.languageId, 'phpx');
+ 	});
 });

--- a/extension/src/test/extension.test.ts
+++ b/extension/src/test/extension.test.ts
@@ -31,25 +31,25 @@ suite('PHPX Extension Test Suite', () => {
 			fs.unlinkSync(tmpFile);
 		}
 	});
- 
- 	test('fixture: page.phpx is detected as phpx language', async () => {
- 		const doc = await vscode.workspace.openTextDocument(
- 			vscode.Uri.file(path.join(fixturesDir, 'page.phpx')),
- 		);
- 		assert.strictEqual(doc.languageId, 'phpx');
- 	});
- 
- 	test('fixture: html-page-template.phpx is detected as phpx language', async () => {
- 		const doc = await vscode.workspace.openTextDocument(
- 			vscode.Uri.file(path.join(fixturesDir, 'html-page-template.phpx')),
- 		);
- 		assert.strictEqual(doc.languageId, 'phpx');
- 	});
- 
- 	test('fixture: syntax-samples.phpx is detected as phpx language', async () => {
- 		const doc = await vscode.workspace.openTextDocument(
- 			vscode.Uri.file(path.join(fixturesDir, 'syntax-samples.phpx')),
- 		);
- 		assert.strictEqual(doc.languageId, 'phpx');
- 	});
+
+	test('fixture: page.phpx is detected as phpx language', async () => {
+		const doc = await vscode.workspace.openTextDocument(
+			vscode.Uri.file(path.join(fixturesDir, 'page.phpx')),
+		);
+		assert.strictEqual(doc.languageId, 'phpx');
+	});
+
+	test('fixture: html-page-template.phpx is detected as phpx language', async () => {
+		const doc = await vscode.workspace.openTextDocument(
+			vscode.Uri.file(path.join(fixturesDir, 'html-page-template.phpx')),
+		);
+		assert.strictEqual(doc.languageId, 'phpx');
+	});
+
+	test('fixture: syntax-samples.phpx is detected as phpx language', async () => {
+		const doc = await vscode.workspace.openTextDocument(
+			vscode.Uri.file(path.join(fixturesDir, 'syntax-samples.phpx')),
+		);
+		assert.strictEqual(doc.languageId, 'phpx');
+	});
 });

--- a/src/compiler/PragmaFormatter.php
+++ b/src/compiler/PragmaFormatter.php
@@ -2,8 +2,6 @@
 
 namespace Attitude\PHPX\Compiler;
 
-require_once 'FormatterInterface.php';
-
 final class PragmaFormatter implements FormatterInterface {
   public function __construct(
     private string $pragma = 'html',

--- a/src/language-server/CompletionProvider.php
+++ b/src/language-server/CompletionProvider.php
@@ -125,7 +125,7 @@ final class CompletionProvider
                     'kind' => self::KIND_KEYWORD,
                     'detail' => $isVoid ? 'HTML void element' : 'HTML element',
                     'insertText' => $isVoid ? "{$tag} />" : "{$tag}>$1</{$tag}>",
-                    'insertTextFormat' => 2,
+                    'insertTextFormat' => 2, // Snippet
                 ];
             }
         }

--- a/src/language-server/CompletionProvider.php
+++ b/src/language-server/CompletionProvider.php
@@ -125,7 +125,7 @@ final class CompletionProvider
                     'kind' => self::KIND_KEYWORD,
                     'detail' => $isVoid ? 'HTML void element' : 'HTML element',
                     'insertText' => $isVoid ? "{$tag} />" : "{$tag}>$1</{$tag}>",
-                    'insertTextFormat' => 2, // Snippet
+                    'insertTextFormat' => 2,
                 ];
             }
         }
@@ -211,7 +211,6 @@ final class CompletionProvider
      */
     private function isInsideTag(TextDocumentItem $document, int $line, int $character): bool
     {
-        // Build source from document start up to the cursor
         $lines = $document->getLines();
         $source = implode("\n", array_slice($lines, 0, $line)) . "\n" . substr($lines[$line] ?? '', 0, $character);
 
@@ -221,7 +220,9 @@ final class CompletionProvider
             class_exists(\Attitude\PHPX\Parser\TokensList::class);
             $tokens = \Attitude\PHPX\Parser\Token::tokenize($source);
         } catch (\Throwable) {
-            // Fallback: simple heuristic for mid-typing states
+            // Fallback: simple heuristic for mid-typing states where incomplete
+            // source cannot be tokenized. Cursor is inside a tag when the last
+            // '<' appears after the last '>'.
             $lastOpen = strrpos($source, '<');
             $lastClose = strrpos($source, '>');
             return $lastOpen !== false && ($lastClose === false || $lastOpen > $lastClose);

--- a/src/language-server/HoverProvider.php
+++ b/src/language-server/HoverProvider.php
@@ -27,20 +27,17 @@ final class HoverProvider
             return null;
         }
 
-        // Check if this is a fragment — must happen before getWordAt() because
-        // <> and </> consist of non-word characters that getWordAt() would reject.
-        // Scan all occurrences on the line (not just the first) so that later
-        // fragments on the same line are detected correctly.
+        // Fragment check must happen before findTagAtPosition: TagScanner skips
+        // TX_FRAGMENT_ELEMENT_OPEN entirely, so <> and </> are invisible to it.
+        // Also before getWordAt(), since <> and </> consist of non-word characters
+        // that getWordAt() would reject.
         $fragmentHover = $this->checkFragmentHover($lineText, $line, $character);
         if ($fragmentHover !== null) {
             return $fragmentHover;
         }
 
-        // Check if it's an HTML/custom element tag name — delegate to TagScanner
-        // which tokenizes the full document and correctly ignores tags inside
-        // quoted attribute strings and {…} expression containers. This must happen
-        // before getWordAt() so that hovering on a hyphen in "my-component" still
-        // resolves to the full tag name rather than returning null early.
+        // Check element tag names before getWordAt() so that hovering on a hyphen
+        // in "my-component" resolves to the full tag name rather than returning null.
         $tag = TagScanner::findTagAtPosition($document->text, $line, $character);
         if ($tag !== null) {
             $tagName = $tag['name'];
@@ -70,8 +67,6 @@ final class HoverProvider
 
         [$wordText, $startChar, $endChar] = $word;
 
-        // Check if it's an attribute name — guard against cursor being inside a string
-        // or expression context (e.g. data="className" must not trigger attribute hover).
         if (isset(self::ATTRIBUTE_DOCS[$wordText])
             && !$this->isInsideStringOrExpression(substr($lineText, 0, $startChar))
         ) {
@@ -130,7 +125,8 @@ final class HoverProvider
     {
         $fragmentMsg = "**PHPX Fragment** `<>...</>`\n\nA wrapper for grouping multiple elements without adding an extra node to the DOM.";
 
-        // Check all </> first (longer match prevents <> matching the < of </>)
+        // Check </> before <> — "</>" contains "<>" as a substring, so checking
+        // the longer token first prevents a false <> match inside </>.
         $offset = 0;
         while (($pos = strpos($lineText, '</>', $offset)) !== false) {
             if ($character >= $pos && $character < $pos + 3) {

--- a/src/language-server/TagScanner.php
+++ b/src/language-server/TagScanner.php
@@ -29,8 +29,10 @@ final class TagScanner
      */
     public static function scan(string $source): array
     {
-        // Ensure TokensList.php is loaded — its file-scope constants (TX_*)
-        // are needed below but aren't autoloaded until the class is referenced.
+        // Force-load TokensList so its file-scope TX_* constants are defined.
+        // Autoloaders map class names to files, not bare constants — without this
+        // the TX_FRAGMENT_ELEMENT_OPEN / TX_ELEMENT_OPENING_OPEN references below
+        // would throw "Undefined constant".
         class_exists(\Attitude\PHPX\Parser\TokensList::class);
 
         try {
@@ -56,21 +58,22 @@ final class TagScanner
                 continue;
             }
 
-            // Skip any < that appears inside an expression container
+            // Skip any token inside an expression container
             if ($depth > 0) {
                 continue;
             }
 
-            // Skip fragments (<> / </>)
+            // Fragments (<>) carry no name — skip. TX_FRAGMENT_ELEMENT_OPEN is a
+            // synthetic id assigned by Token::tokenize() when PHP emits T_IS_NOT_EQUAL
+            // for the <> digraph. The closing </> never forms a named tag entry either.
             if ($token->id === \Attitude\PHPX\Parser\TX_FRAGMENT_ELEMENT_OPEN) {
                 continue;
             }
 
-            // Opening tag: < followed by T_STRING (aligned with Parser::parseElementName())
             if ($token->id === \Attitude\PHPX\Parser\TX_ELEMENT_OPENING_OPEN) {
                 $next = $tokens[$i + 1] ?? null;
 
-                // Check for closing tag: < / name
+                // Closing tag: < / name
                 if ($next !== null && $next->text === '/') {
                     $nameToken = $tokens[$i + 2] ?? null;
                     if ($nameToken !== null && $nameToken->id === T_STRING) {
@@ -78,7 +81,7 @@ final class TagScanner
                         $nameStart = self::toCharOffset($source, $nameToken->pos);
                         $tags[] = [
                             'name' => $name,
-                            'line' => $nameToken->line - 1, // tokens are 1-based
+                            'line' => $nameToken->line - 1, // PHP tokenizer is 1-based; LSP is 0-based
                             'start' => $nameStart,
                             'end' => $nameStart + strlen($name),
                             'kind' => 'close',
@@ -110,17 +113,20 @@ final class TagScanner
     }
 
     /**
-     * Read a potentially hyphenated tag name starting at token index $start.
-     * Returns "my-component" for tokens [my, -, component].
+     * Read a potentially hyphenated tag name starting at $tokens[$start].
+     * Returns "my-component" for the token sequence [my, -, component].
+     *
+     * PHP tokenizes "my-component" as three separate tokens, so the name must be
+     * reassembled. A hyphen is consumed only when followed by a word token —
+     * T_STRING or any token whose text matches /^\w+$/ (covers numeric segments
+     * like "2" in "x-2"). Aligned with Parser::parseElementName().
      */
     private static function readTagName(array $tokens, int $start, int $count): string
     {
         $name = $tokens[$start]->text;
         $j = $start + 1;
 
-        // Hyphenated segments: "-" must be followed by a word token — aligned with
-        // Parser::parseElementName / tokenAtCursorIsWord: T_STRING OR any token
-        // whose text matches /^\w+$/ (covers numeric segments like "2" in x-2).
+        // The bound $j < $count - 1 ensures $tokens[$j + 1] exists before peeking.
         while ($j < $count - 1 && $tokens[$j]->text === '-' && isset($tokens[$j + 1]) &&
                ($tokens[$j + 1]->id === T_STRING || preg_match('/^\w+$/', $tokens[$j + 1]->text))) {
             $name .= '-' . $tokens[$j + 1]->text;
@@ -132,16 +138,17 @@ final class TagScanner
 
     /**
      * Check if the tag starting at $nameIndex is self-closing.
-     * Scans forward past attributes until finding > or />.
+     * Scans forward past attributes until finding /> or >.
      */
     private static function isSelfClosing(array $tokens, int $nameIndex, int $count, string $name): bool
     {
-        // Skip past the tag name tokens
+        // Skip past the tag name tokens.
+        // A simple name ("div") is 1 token; each hyphenated segment adds 2 ('-' + word).
         $j = $nameIndex;
-        $nameLen = substr_count($name, '-') * 2 + 1; // each hyphenated segment = 2 tokens, plus the first
+        $nameLen = substr_count($name, '-') * 2 + 1; // e.g. "my-foo" → 1*2+1 = 3 tokens
         $j += $nameLen;
 
-        // Nesting depth for { } and ( ) — skip over attribute expressions
+        // Nesting depth for { } ( ) [ ] — skip over attribute expressions
         $depth = 0;
 
         while ($j < $count) {
@@ -170,13 +177,17 @@ final class TagScanner
     }
 
     /**
-     * Convert a byte offset (from Token::$pos) to the byte offset within
-     * the token's line. Since the server negotiates positionEncoding: utf-8,
-     * byte offsets equal UTF-8 code unit offsets, which is what LSP expects.
+     * Convert a byte offset (from Token::$pos) to the character offset within
+     * the token's line, suitable for use as an LSP character value.
+     *
+     * Finds the start of the line containing $bytePos by searching backwards
+     * for the last newline. The negative third argument to strrpos() is an
+     * offset from the end of the string: ($bytePos - strlen($source)) is
+     * negative, so strrpos() starts its backward search at byte $bytePos.
+     * When no newline is found the byte is on the first line (line start = 0).
      */
     private static function toCharOffset(string $source, int $bytePos): int
     {
-        // Find the start of the line containing this byte position
         $lineStart = strrpos($source, "\n", $bytePos - strlen($source));
         $lineStart = $lineStart === false ? 0 : $lineStart + 1;
 

--- a/src/parser/TokensList.php
+++ b/src/parser/TokensList.php
@@ -14,7 +14,9 @@ const TX_PARENTHESIS_CLOSE = 41;
 const TX_SQUARE_BRACKET_OPEN = 91;
 /** Token for ], value of ord(']'); */
 const TX_SQUARE_BRACKET_CLOSE = 93;
-/** Token for <>, value of word_ord('<>'); */
+/** Synthetic token id for the PHPX fragment opener `<>`. PHP tokenizes `<>` as T_IS_NOT_EQUAL;
+ *  Token::tokenize() replaces that id with this constant so the parser treats `<>` as a
+ *  fragment open rather than a not-equal operator. Value = (ord('>') << 8) | ord('<') = 0x3E3C. */
 const TX_FRAGMENT_ELEMENT_OPEN = 15932;
 /** Token sequence for </>, value of ['<', '/', '>']; */
 const TX_FRAGMENT_ELEMENT_CLOSING_SEQUENCE = ['<', '/', '>'];
@@ -26,14 +28,14 @@ const TX_ELEMENT_OPENING_OPEN_SEQUENCE = ['<', T_STRING];
 const TX_PHP_OPEN_SEQUENCE = ['<', '?'];
 /** Token sequence for />, value of ['/', '>']; */
 const TX_ELEMENT_SELF_CLOSING_SEQUENCE = ['/', '>'];
-/** Token for >, value of ord('>'); */
+/** Token for `>` closing an opening tag — the `>` in `<div>`; value of ord('>') = 62. */
 const TX_ELEMENT_OPENING_CLOSE = 62;
 /** Token sequence for </T_STRING, value of ['<', '/', T_STRING]; */
 const TX_ELEMENT_CLOSING_OPEN_SEQUENCE = ['<', '/', T_STRING];
-/** Token for >, value of ord('>'); */
+/** Token for `>` closing a closing tag — the `>` in `</div>`; value of ord('>') = 62. */
 const TX_ELEMENT_CLOSING_CLOSE = 62;
 /** Token for Template Literal backtick, value of ord('`'); */
-const TX_TEMPLATE_LITERAL = 96; // ord('`');
+const TX_TEMPLATE_LITERAL = 96;
 
 final class TokensList implements \JsonSerializable, \Iterator {
 	private int $cursor = 0;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,6 +4,9 @@ use Pest\Repositories\SnapshotRepository;
 use Pest\TestSuite;
 
 require_once __DIR__ . '/helpers/warnings.php';
+if (!class_exists(\Attitude\PHPX\Logger::class)) {
+    require_once __DIR__ . '/helpers/Logger.php';
+}
 require_once __DIR__ . '/language-server/helpers.php';
 
 $suite = TestSuite::getInstance();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 use Pest\Repositories\SnapshotRepository;
 use Pest\TestSuite;
 
+require_once __DIR__ . '/helpers/warnings.php';
 require_once __DIR__ . '/language-server/helpers.php';
 
 $suite = TestSuite::getInstance();

--- a/tests/compiler/Compiler.spec.php
+++ b/tests/compiler/Compiler.spec.php
@@ -519,6 +519,22 @@ PHP
     expect($pragmaCompiler->getCompiled())->toMatchSnapshot();
   });
 
+  it('compiles the React-18 Title component fixture', function () {
+    $compiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
+    $compiler->compile(file_get_contents(__DIR__.'/../renderer/react-18/components/Title.phpx'));
+    expect($compiler->getCompiled())->toBe(
+      file_get_contents(__DIR__.'/../renderer/react-18/components/Title.php')
+    );
+  });
+
+  it('produces correct output with a logger attached', function () {
+    $compiler = newCompiler(withLogger: true, parser: newParser(withLogger: true));
+    ob_start();
+    $compiler->compile('<>Hello, {$name ?? \'unnamed\'}!</>');
+    ob_end_clean();
+    expect($compiler->getCompiled())->toBe("['Hello, ', (\$name ?? 'unnamed'), '!']");
+  });
+
   it('should ignore null children and null atribudes', function () {
     $defaultCompiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
     $defaultCompiler->compile('<div></div>');

--- a/tests/compiler/Compiler.spec.php
+++ b/tests/compiler/Compiler.spec.php
@@ -5,6 +5,7 @@ use Attitude\PHPX\Compiler\Compiler;
 use Attitude\PHPX\Compiler\FormatterInterface;
 use Attitude\PHPX\Compiler\PragmaFormatter;
 use Attitude\PHPX\Parser\Parser;
+use Attitude\PHPX\Parser\TokensList;
 
 require_once __DIR__.'/../../src/index.php';
 
@@ -533,6 +534,26 @@ PHP
     $compiler->compile('<>Hello, {$name ?? \'unnamed\'}!</>');
     ob_end_clean();
     expect($compiler->getCompiled())->toBe("['Hello, ', (\$name ?? 'unnamed'), '!']");
+  });
+
+  it('__toString returns the compiled output', function () {
+    $compiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
+    $compiler->compile('<p>Hello, {$name}!</p>');
+    expect((string) $compiler)->toBe($compiler->getCompiled());
+  });
+
+  it('getSource returns the original source passed to compile()', function () {
+    $source = '<p>Hello, {$name}!</p>';
+    $compiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
+    $compiler->compile($source);
+    expect($compiler->getSource())->toBe($source);
+  });
+
+  it('getTokens returns the TokensList for the compiled source', function () {
+    $compiler = newCompiler(withLogger: false, parser: newParser(withLogger: false));
+    $compiler->compile('<p>Hello</p>');
+    expect($compiler->getTokens())->toBeInstanceOf(TokensList::class);
+    expect((string) $compiler->getTokens())->toBe('<p>Hello</p>');
   });
 
   it('should ignore null children and null atribudes', function () {

--- a/tests/compiler/Compiler.spec.php
+++ b/tests/compiler/Compiler.spec.php
@@ -531,8 +531,11 @@ PHP
   it('produces correct output with a logger attached', function () {
     $compiler = newCompiler(withLogger: true, parser: newParser(withLogger: true));
     ob_start();
-    $compiler->compile('<>Hello, {$name ?? \'unnamed\'}!</>');
-    ob_end_clean();
+    try {
+      $compiler->compile('<>Hello, {$name ?? \'unnamed\'}!</>');
+    } finally {
+      ob_end_clean();
+    }
     expect($compiler->getCompiled())->toBe("['Hello, ', (\$name ?? 'unnamed'), '!']");
   });
 

--- a/tests/compiler/Compiler.spec.php
+++ b/tests/compiler/Compiler.spec.php
@@ -531,11 +531,8 @@ PHP
   it('produces correct output with a logger attached', function () {
     $compiler = newCompiler(withLogger: true, parser: newParser(withLogger: true));
     ob_start();
-    try {
-      $compiler->compile('<>Hello, {$name ?? \'unnamed\'}!</>');
-    } finally {
-      ob_end_clean();
-    }
+    $compiler->compile('<>Hello, {$name ?? \'unnamed\'}!</>');
+    ob_end_clean();
     expect($compiler->getCompiled())->toBe("['Hello, ', (\$name ?? 'unnamed'), '!']");
   });
 


### PR DESCRIPTION
## Summary

- **CI**: Add GitHub Actions workflow with PHP 8.3–8.5 matrix and extension tests job
- **fix**: Guard `Logger` class load with `class_exists` to prevent fatal redeclaration on case-sensitive filesystems (Linux CI)
- **fix**: Remove macOS-specific PHP grammar path from `test:grammar` script; add `phpx-function.test.phpx` grammar tests for PHPX inside PHP function bodies
- **refactor**: Remove dead `require_once` from `PragmaFormatter.php`; correct and clarify comments in `TokensList`, `CompletionProvider`, `HoverProvider`, and `TagScanner`
- **tests**: Extend `Compiler.spec.php` with `__toString`, `getSource`, and `getTokens` coverage; add React-18 Title component fixture; add extension integration tests

## Test plan

- [ ] PHP tests pass on 8.3, 8.4, 8.5 (`vendor/bin/pest`)
- [ ] Grammar tests pass on Linux CI (`pnpm test:grammar` — no macOS path required)
- [ ] Extension integration tests pass (`xvfb-run -a pnpm test`)
- [ ] `Logger` class loads cleanly on both macOS (case-insensitive FS) and Linux (case-sensitive FS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)