### PR TITLE
feat(Compiler,LSP): Implement Extensibility

### DIFF
--- a/extension/.vscodeignore
+++ b/extension/.vscodeignore
@@ -12,5 +12,6 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+!types/**/*.d.ts
 RESEARCH.md
 package-lock.json

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "phpx-language-support",
   "displayName": "PHPX Language Support",
   "description": "Syntax highlighting and language support for PHPX - JSX-like syntax for PHP",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "attitude",
   "license": "MIT",
   "engines": {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -13,6 +13,14 @@ import {
 	PHPXRenameProvider,
 	PHPXImplementationProvider,
 } from './providers';
+import {
+	initTsxQuery,
+	disposeTsxQuery,
+	getTsxAttributeCompletions,
+	getTsxAttributeHover,
+	detectTagAtCursor,
+	detectTagAndAttributeAtCursor,
+} from './tsxQuery';
 
 const PHPX_SELECTOR: vscode.DocumentSelector = {
 	language: 'phpx',
@@ -47,6 +55,83 @@ export function activate(context: vscode.ExtensionContext) {
 			outputChannel.appendLine('[PHPX] Language Server client started');
 		}
 	}
+
+	// ─── TypeScript JSX attribute query ──────────────────────────────────────
+	//
+	// Initialises a small virtual TypeScript project using phpx-intrinsics.d.ts
+	// (the PHPX JSX type declarations, no React) in the extension's global
+	// storage directory.  This lets us query VS Code's built-in TypeScript
+	// language service for per-element HTML attribute completions and types.
+	//
+	// The query is purely additive — if the TypeScript server is unavailable
+	// the PHPX LSP's own completions continue to work unchanged.
+	// ─────────────────────────────────────────────────────────────────────────
+
+	// Fire-and-forget: initialisation happens async so activation stays fast
+	initTsxQuery(context).catch((err) => {
+		outputChannel.appendLine(`[PHPX] TSX query init error: ${err}`);
+	});
+
+	// Supplementary completion provider: queries TypeScript for per-element
+	// HTML attribute types and merges them with the PHPX LSP's own suggestions.
+	context.subscriptions.push(
+		vscode.languages.registerCompletionItemProvider(
+			PHPX_SELECTOR,
+			{
+				async provideCompletionItems(
+					document: vscode.TextDocument,
+					position: vscode.Position,
+				): Promise<vscode.CompletionItem[] | undefined> {
+					const tagName = detectTagAtCursor(document, position);
+					if (!tagName) {
+						return undefined;
+					}
+
+					// Only trigger for HTML intrinsic elements (lowercase first char)
+					if (tagName[0] !== tagName[0].toLowerCase() || tagName[0] === tagName[0].toUpperCase()) {
+						return undefined;
+					}
+
+					return getTsxAttributeCompletions(tagName);
+				},
+			},
+			' ',  // trigger on space (same as PHPX LSP)
+			'\n', // and newline (for multi-line attribute lists)
+		),
+	);
+
+	// Supplementary hover provider: queries TypeScript for attribute type info
+	// when hovering over an HTML attribute name inside a PHPX tag.
+	context.subscriptions.push(
+		vscode.languages.registerHoverProvider(
+			PHPX_SELECTOR,
+			{
+				async provideHover(
+					document: vscode.TextDocument,
+					position: vscode.Position,
+				): Promise<vscode.Hover | undefined> {
+					const hit = detectTagAndAttributeAtCursor(document, position);
+					if (!hit) {
+						return undefined;
+					}
+
+					const markdown = await getTsxAttributeHover(hit.tagName, hit.attrName);
+					if (!markdown) {
+						return undefined;
+					}
+
+					const range = new vscode.Range(
+						position.line, hit.attrStart,
+						position.line, hit.attrEnd,
+					);
+					return new vscode.Hover(
+						new vscode.MarkdownString(markdown),
+						range,
+					);
+				},
+			},
+		),
+	);
 
 	// ─── Compilation pipeline ────────────────────────────────────────────────
 	//
@@ -306,6 +391,9 @@ export async function deactivate() {
 		clearTimeout(timer);
 	}
 	compilationTimers.clear();
+
+	// Clean up the TypeScript JSX attribute query environment
+	disposeTsxQuery();
 
 	// Stop the PHPX Language Server
 	await stopLanguageClient();

--- a/extension/src/tsxQuery.ts
+++ b/extension/src/tsxQuery.ts
@@ -1,0 +1,376 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * TypeScript JSX Attribute Query
+ *
+ * Sets up a small virtual TypeScript project that uses phpx-intrinsics.d.ts
+ * (the PHPX JSX type declarations) and queries VS Code's built-in TypeScript
+ * language service for HTML element attribute completions and hover info.
+ *
+ * Architecture:
+ *   1. At activation, write a query directory to globalStoragePath containing:
+ *      • tsconfig.json  — enables jsx:"react", jsxFactory:"h", lib:["dom"]
+ *      • phpx-intrinsics.d.ts  — copied from the extension's types/ folder
+ *      • .query.tsx  — tiny JSX snippet used as the completion/hover target
+ *   2. Per request, rewrite .query.tsx and call the appropriate
+ *      vscode.execute*Provider command on it.
+ *   3. Filter & cache results; return them to the PHPX providers.
+ */
+
+let queryDir: string | undefined;
+let queryTsxPath: string | undefined;
+
+/** Cache: tag name → completion items returned by TypeScript */
+const completionCache = new Map<string, vscode.CompletionItem[]>();
+
+/** Cache: `tagName:attrName` → hover markdown string */
+const hoverCache = new Map<string, string | null>();
+
+// ─── Initialization & disposal ────────────────────────────────────────────────
+
+/**
+ * Initialize the TypeScript query environment.
+ * Must be called once during extension activation.
+ */
+export async function initTsxQuery(context: vscode.ExtensionContext): Promise<void> {
+    queryDir = path.join(context.globalStorageUri.fsPath, 'tsx-query');
+    queryTsxPath = path.join(queryDir, '.query.tsx');
+
+    try {
+        fs.mkdirSync(queryDir, { recursive: true });
+
+        // Write tsconfig.json — enables JSX + DOM lib for the query file
+        const intrinsicsPath = path.join(context.extensionPath, 'types', 'phpx-intrinsics.d.ts');
+        const tsconfig = {
+            compilerOptions: {
+                target: 'ES2020',
+                lib: ['ES2020', 'DOM'],
+                jsx: 'react',
+                jsxFactory: 'h',
+                strict: false,
+                noEmit: true,
+                skipLibCheck: true,
+                noUnusedLocals: false,
+                noUnusedParameters: false,
+            },
+            // Reference the shipped phpx-intrinsics.d.ts from the extension
+            files: [
+                './.query.tsx',
+                intrinsicsPath,
+            ],
+        };
+        fs.writeFileSync(
+            path.join(queryDir, 'tsconfig.json'),
+            JSON.stringify(tsconfig, null, 2),
+            'utf-8',
+        );
+
+        // Write an initial placeholder so TypeScript's language server indexes
+        // the query file and warms up the project immediately.
+        fs.writeFileSync(queryTsxPath, '/* @jsx h */\nconst _warmup = <div />;\n', 'utf-8');
+
+        // Open the document so VS Code's TypeScript language server picks it up
+        const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(queryTsxPath));
+        // Request completions once to warm up the TypeScript server project
+        await vscode.commands.executeCommand(
+            'vscode.executeCompletionItemProvider',
+            doc.uri,
+            new vscode.Position(1, 18), // inside `<div ` on line 1
+        );
+    } catch (err) {
+        // Silently degrade — the PHPX LSP's own completions still work
+        console.error('[PHPX] tsxQuery init failed:', err);
+        queryDir = undefined;
+        queryTsxPath = undefined;
+    }
+}
+
+/**
+ * Dispose of the query environment.
+ * Called on extension deactivation.
+ */
+export function disposeTsxQuery(): void {
+    completionCache.clear();
+    hoverCache.clear();
+    if (queryTsxPath) {
+        try { fs.unlinkSync(queryTsxPath); } catch { /* ignore */ }
+    }
+    queryDir = undefined;
+    queryTsxPath = undefined;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Write a query snippet to disk and open the document so TypeScript picks it up.
+ * Returns the document, or undefined on failure.
+ */
+async function writeAndOpen(content: string): Promise<vscode.TextDocument | undefined> {
+    if (!queryTsxPath) {
+        return undefined;
+    }
+    try {
+        fs.writeFileSync(queryTsxPath, content, 'utf-8');
+        const uri = vscode.Uri.file(queryTsxPath);
+        return await vscode.workspace.openTextDocument(uri);
+    } catch {
+        return undefined;
+    }
+}
+
+// ─── Completions ──────────────────────────────────────────────────────────────
+
+/**
+ * Get TypeScript-powered attribute completions for an HTML element.
+ *
+ * Rewrites the query .tsx file to `<tagName ` and requests completions
+ * from VS Code's built-in TypeScript language service. Results are cached
+ * per tag name (they're static — DOM types don't change at runtime).
+ */
+export async function getTsxAttributeCompletions(
+    tagName: string,
+): Promise<vscode.CompletionItem[]> {
+    if (!queryDir || !queryTsxPath) {
+        return [];
+    }
+
+    const cached = completionCache.get(tagName);
+    if (cached) {
+        return cached;
+    }
+
+    try {
+        // Write a minimal JSX snippet with the target tag name
+        // Line 0: pragma comment
+        // Line 1: `const _el = <tagName ` ← cursor here for attribute completions
+        const snippet = `/* @jsx h */\nconst _el = <${tagName} `;
+        const doc = await writeAndOpen(snippet);
+        if (!doc) {
+            return [];
+        }
+
+        // Cursor is at the end of line 1, after `<tagName `
+        // Column = length of `const _el = <` (13) + tagName.length + 1 (space)
+        const position = new vscode.Position(1, 13 + tagName.length);
+
+        // Small delay to let TypeScript pick up the file change
+        await new Promise<void>((resolve) => setTimeout(resolve, 150));
+
+        const result = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            doc.uri,
+            position,
+            undefined,        // trigger character
+            10,               // resolve up to N items for full detail
+        );
+
+        if (!result?.items?.length) {
+            completionCache.set(tagName, []);
+            return [];
+        }
+
+        // Keep only JSX attribute-style completions:
+        //   CompletionItemKind.Property (10) — attribute props
+        //   CompletionItemKind.Field    (4)  — may appear for some completions
+        // Drop module imports, keywords, snippets, etc.
+        const items = result.items.filter(
+            (item) =>
+                item.kind === vscode.CompletionItemKind.Property ||
+                item.kind === vscode.CompletionItemKind.Field,
+        );
+
+        completionCache.set(tagName, items);
+        return items;
+    } catch {
+        completionCache.set(tagName, []);
+        return [];
+    }
+}
+
+// ─── Hover ────────────────────────────────────────────────────────────────────
+
+/**
+ * Get TypeScript hover info for an HTML attribute on a given tag.
+ *
+ * Writes a query `.tsx` with the attribute used on the element and calls
+ * `vscode.executeHoverProvider` on the attribute name position.
+ * Returns markdown text or null.
+ */
+export async function getTsxAttributeHover(
+    tagName: string,
+    attrName: string,
+): Promise<string | null> {
+    if (!queryDir || !queryTsxPath) {
+        return null;
+    }
+
+    const cacheKey = `${tagName}:${attrName}`;
+    if (hoverCache.has(cacheKey)) {
+        return hoverCache.get(cacheKey) ?? null;
+    }
+
+    try {
+        // Build a snippet where the attribute appears with a valid value.
+        // Use `attrName={null as any}` so TypeScript parses it without type errors
+        // while still resolving the property type on hover.
+        //
+        // Line 0: `/* @jsx h */`
+        // Line 1: `<tagName attrName={null as any} />`
+        //                   ^ cursor here (col = 1 + tagName.length + 1)
+        const attrCol = 1 + tagName.length + 1; // `<` + tagName + ` `
+        const snippet = `/* @jsx h */\n<${tagName} ${attrName}={null as any} />`;
+
+        const doc = await writeAndOpen(snippet);
+        if (!doc) {
+            return null;
+        }
+
+        const position = new vscode.Position(1, attrCol);
+
+        await new Promise<void>((resolve) => setTimeout(resolve, 150));
+
+        const hovers = await vscode.commands.executeCommand<vscode.Hover[]>(
+            'vscode.executeHoverProvider',
+            doc.uri,
+            position,
+        );
+
+        if (!hovers?.length) {
+            hoverCache.set(cacheKey, null);
+            return null;
+        }
+
+        // Merge all hover contents into a single markdown string
+        const parts: string[] = [];
+        for (const hover of hovers) {
+            for (const content of hover.contents) {
+                if (typeof content === 'string') {
+                    parts.push(content);
+                } else if ('value' in content) {
+                    parts.push(content.value);
+                }
+            }
+        }
+
+        const text = parts.join('\n\n') || null;
+        hoverCache.set(cacheKey, text);
+        return text;
+    } catch {
+        hoverCache.set(cacheKey, null);
+        return null;
+    }
+}
+
+// ─── Tag/attribute detection ──────────────────────────────────────────────────
+
+/**
+ * Detect the HTML tag name that the cursor is inside (for completions).
+ *
+ * Looks at the text before the cursor on the current line for an opening
+ * tag pattern like `<div ` or `<input type="text" `.  Returns the lower-case
+ * tag name, or undefined if not inside a tag.
+ */
+export function detectTagAtCursor(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+): string | undefined {
+    const line = document.lineAt(position).text;
+    const prefix = line.substring(0, position.character);
+
+    // Match the last opening tag before the cursor that hasn't been closed.
+    // Only lowercase-first tags (HTML intrinsic elements).
+    const match = prefix.match(/<([a-z][a-zA-Z0-9-]*)(?:\s[^>]*)?\s\w*$/);
+    if (!match) {
+        return undefined;
+    }
+
+    return match[1].toLowerCase();
+}
+
+/**
+ * Detect the tag name and attribute name at the cursor position (for hover).
+ *
+ * Handles both single-line and multi-line tags by scanning backwards through
+ * document lines from the cursor to find the opening `<tagName`.
+ *
+ * Returns { tagName, attrName, attrStart, attrEnd } or undefined.
+ */
+export function detectTagAndAttributeAtCursor(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+): { tagName: string; attrName: string; attrStart: number; attrEnd: number } | undefined {
+    const line = document.lineAt(position).text;
+    const char = position.character;
+
+    // Find the word (attribute name) under the cursor
+    let start = char;
+    let end = char;
+    while (start > 0 && isWordChar(line[start - 1])) {
+        start--;
+    }
+    while (end < line.length && isWordChar(line[end])) {
+        end++;
+    }
+    if (start === end) {
+        return undefined;
+    }
+    const attrName = line.substring(start, end);
+
+    // Must be followed by `=` or whitespace or `/` or `>` to look like an attribute
+    // (not a tag name, text content, etc.)
+    const afterAttr = line[end];
+    if (afterAttr !== undefined && afterAttr !== '=' && afterAttr !== ' '
+        && afterAttr !== '\t' && afterAttr !== '/' && afterAttr !== '>') {
+        return undefined;
+    }
+
+    // Build text from document start up to the attribute position to find the tag.
+    // Scan backwards through lines to find `<tagName`.
+    let textBefore = line.substring(0, start);
+    let tagName: string | undefined;
+
+    // Try current line first (fast path)
+    const tagMatch = textBefore.match(/<([a-z][a-zA-Z0-9-]*)(?:\s[^>]*)?$/);
+    if (tagMatch) {
+        tagName = tagMatch[1];
+    } else {
+        // Multi-line tag: scan backwards through preceding lines
+        for (let ln = position.line - 1; ln >= 0 && ln >= position.line - 20; ln--) {
+            textBefore = document.lineAt(ln).text + '\n' + textBefore;
+            const multiMatch = textBefore.match(/<([a-z][a-zA-Z0-9-]*)(?:\s[^>]*)?$/s);
+            if (multiMatch) {
+                tagName = multiMatch[1];
+                break;
+            }
+            // Stop if we encounter a `>` — we've left the tag
+            if (document.lineAt(ln).text.includes('>')) {
+                break;
+            }
+        }
+    }
+
+    if (!tagName) {
+        return undefined;
+    }
+
+    // Make sure the word isn't the tag name itself (e.g., cursor on `img` in `<img`)
+    if (attrName === tagName) {
+        return undefined;
+    }
+
+    return {
+        tagName: tagName.toLowerCase(),
+        attrName,
+        attrStart: start,
+        attrEnd: end,
+    };
+}
+
+function isWordChar(ch: string | undefined): boolean {
+    if (!ch) {
+        return false;
+    }
+    return /[a-zA-Z0-9_]/.test(ch);
+}

--- a/extension/types/phpx-intrinsics.d.ts
+++ b/extension/types/phpx-intrinsics.d.ts
@@ -1,0 +1,861 @@
+/// <reference lib="dom" />
+
+/**
+ * PHPX JSX type declarations — no React required.
+ *
+ * Provides HTML attribute types for the /* @jsx h *\/ pragma.
+ * Uses TypeScript's built-in DOM types from lib.dom.d.ts.
+ *
+ * Usage in a project tsconfig.json:
+ *   "jsx": "react",
+ *   "jsxFactory": "h",
+ *   "types": ["path/to/phpx-intrinsics"]   // or /// <reference path="..." />
+ */
+
+// ─── JSX factory (no-op signature — only the types matter for PHPX) ───────────
+
+declare function h(
+    type: string | ((props: Record<string, unknown>) => unknown),
+    props: Record<string, unknown> | null,
+    ...children: unknown[]
+): unknown;
+
+declare namespace h {
+    namespace JSX {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        type Element = any;
+        interface IntrinsicElements extends PHPXIntrinsicElements {}
+    }
+}
+
+// Global JSX namespace — TypeScript checks this for `.tsx` JSX type safety
+declare global {
+    namespace JSX {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        type Element = any;
+        interface IntrinsicElements extends PHPXIntrinsicElements {}
+    }
+}
+
+// ─── Base attribute helpers ────────────────────────────────────────────────────
+
+type PHPXEventHandler<E extends Event = Event> = (event: E) => void;
+
+/** CSS styles as a key-value map (PHPX convention) */
+type PHPXStyle = Record<string, string | number>;
+
+// ─── Common HTML attributes shared by all elements ────────────────────────────
+
+interface PHPXHTMLAttributes {
+    // Core
+    id?: string;
+    /** Maps to the HTML `class` attribute */
+    className?: string;
+    title?: string;
+    lang?: string;
+    dir?: 'ltr' | 'rtl' | 'auto';
+    hidden?: boolean;
+
+    // Inline style as a key/value map (PHPX compiles to HTML style string)
+    style?: PHPXStyle;
+
+    // Interactivity
+    /** Maps to the HTML `tabindex` attribute */
+    tabIndex?: number;
+    contentEditable?: boolean | 'inherit' | 'plaintext-only';
+    draggable?: boolean;
+    spellCheck?: boolean;
+    translate?: 'yes' | 'no';
+    inert?: boolean;
+    popover?: 'auto' | 'manual' | '';
+
+    // Accessibility
+    role?: string;
+    slot?: string;
+    part?: string;
+    exportparts?: string;
+    is?: string;
+    nonce?: string;
+
+    // PHPX-specific
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    children?: any;
+    key?: string | number | null;
+    dangerouslySetInnerHTML?: { __html: string };
+
+    // ─── Event handlers (JSX/PHPX camelCase names) ───────────────────────────
+
+    // Mouse
+    onClick?: PHPXEventHandler<MouseEvent>;
+    onDoubleClick?: PHPXEventHandler<MouseEvent>;
+    onMouseEnter?: PHPXEventHandler<MouseEvent>;
+    onMouseLeave?: PHPXEventHandler<MouseEvent>;
+    onMouseOver?: PHPXEventHandler<MouseEvent>;
+    onMouseOut?: PHPXEventHandler<MouseEvent>;
+    onMouseDown?: PHPXEventHandler<MouseEvent>;
+    onMouseUp?: PHPXEventHandler<MouseEvent>;
+    onMouseMove?: PHPXEventHandler<MouseEvent>;
+    onContextMenu?: PHPXEventHandler<MouseEvent>;
+    onAuxClick?: PHPXEventHandler<MouseEvent>;
+
+    // Keyboard
+    onKeyDown?: PHPXEventHandler<KeyboardEvent>;
+    onKeyUp?: PHPXEventHandler<KeyboardEvent>;
+    /** @deprecated Use onKeyDown instead */
+    onKeyPress?: PHPXEventHandler<KeyboardEvent>;
+
+    // Form / input
+    onChange?: PHPXEventHandler<Event>;
+    onInput?: PHPXEventHandler<InputEvent>;
+    onBeforeInput?: PHPXEventHandler<InputEvent>;
+    onSubmit?: PHPXEventHandler<SubmitEvent>;
+    onReset?: PHPXEventHandler<Event>;
+    onInvalid?: PHPXEventHandler<Event>;
+
+    // Focus
+    onFocus?: PHPXEventHandler<FocusEvent>;
+    onBlur?: PHPXEventHandler<FocusEvent>;
+    onFocusIn?: PHPXEventHandler<FocusEvent>;
+    onFocusOut?: PHPXEventHandler<FocusEvent>;
+
+    // Pointer
+    onPointerDown?: PHPXEventHandler<PointerEvent>;
+    onPointerUp?: PHPXEventHandler<PointerEvent>;
+    onPointerMove?: PHPXEventHandler<PointerEvent>;
+    onPointerEnter?: PHPXEventHandler<PointerEvent>;
+    onPointerLeave?: PHPXEventHandler<PointerEvent>;
+    onPointerOver?: PHPXEventHandler<PointerEvent>;
+    onPointerOut?: PHPXEventHandler<PointerEvent>;
+    onPointerCancel?: PHPXEventHandler<PointerEvent>;
+    onGotPointerCapture?: PHPXEventHandler<PointerEvent>;
+    onLostPointerCapture?: PHPXEventHandler<PointerEvent>;
+
+    // Touch
+    onTouchStart?: PHPXEventHandler<TouchEvent>;
+    onTouchEnd?: PHPXEventHandler<TouchEvent>;
+    onTouchMove?: PHPXEventHandler<TouchEvent>;
+    onTouchCancel?: PHPXEventHandler<TouchEvent>;
+
+    // Drag
+    onDrag?: PHPXEventHandler<DragEvent>;
+    onDragStart?: PHPXEventHandler<DragEvent>;
+    onDragEnd?: PHPXEventHandler<DragEvent>;
+    onDragOver?: PHPXEventHandler<DragEvent>;
+    onDragEnter?: PHPXEventHandler<DragEvent>;
+    onDragLeave?: PHPXEventHandler<DragEvent>;
+    onDrop?: PHPXEventHandler<DragEvent>;
+
+    // Scroll / wheel
+    onScroll?: PHPXEventHandler<Event>;
+    onScrollEnd?: PHPXEventHandler<Event>;
+    onWheel?: PHPXEventHandler<WheelEvent>;
+
+    // Clipboard
+    onCopy?: PHPXEventHandler<ClipboardEvent>;
+    onCut?: PHPXEventHandler<ClipboardEvent>;
+    onPaste?: PHPXEventHandler<ClipboardEvent>;
+
+    // Lifecycle / media
+    onLoad?: PHPXEventHandler<Event>;
+    onError?: PHPXEventHandler<ErrorEvent | Event>;
+    onAbort?: PHPXEventHandler<Event>;
+
+    // Animation / transition
+    onAnimationStart?: PHPXEventHandler<AnimationEvent>;
+    onAnimationEnd?: PHPXEventHandler<AnimationEvent>;
+    onAnimationIteration?: PHPXEventHandler<AnimationEvent>;
+    onTransitionStart?: PHPXEventHandler<TransitionEvent>;
+    onTransitionEnd?: PHPXEventHandler<TransitionEvent>;
+    onTransitionCancel?: PHPXEventHandler<TransitionEvent>;
+
+    // Selection
+    onSelect?: PHPXEventHandler<Event>;
+    onSelectionChange?: PHPXEventHandler<Event>;
+
+    // Toggle
+    onToggle?: PHPXEventHandler<Event>;
+    onBeforeToggle?: PHPXEventHandler<Event>;
+
+    // Fullscreen / picture-in-picture
+    onFullscreenChange?: PHPXEventHandler<Event>;
+    onFullscreenError?: PHPXEventHandler<Event>;
+
+    // Data wildcard attributes (data-*)
+    [key: `data-${string}`]: string | number | boolean | undefined;
+    // ARIA wildcard attributes (aria-*)
+    [key: `aria-${string}`]: string | number | boolean | undefined;
+}
+
+// ─── Element-specific attribute interfaces ────────────────────────────────────
+
+interface PHPXAnchorAttributes extends PHPXHTMLAttributes {
+    href?: string;
+    target?: '_blank' | '_self' | '_parent' | '_top' | (string & {});
+    rel?: string;
+    download?: string | boolean;
+    /** Maps to `hreflang` */
+    hrefLang?: string;
+    type?: string;
+    referrerPolicy?: ReferrerPolicy;
+    ping?: string;
+}
+
+interface PHPXAreaAttributes extends PHPXHTMLAttributes {
+    alt?: string;
+    coords?: string;
+    href?: string;
+    shape?: 'rect' | 'circle' | 'poly' | 'default';
+    target?: string;
+    download?: string;
+    rel?: string;
+    referrerPolicy?: ReferrerPolicy;
+}
+
+interface PHPXAudioAttributes extends PHPXHTMLAttributes {
+    src?: string;
+    /** Maps to `autoplay` */
+    autoPlay?: boolean;
+    controls?: boolean;
+    loop?: boolean;
+    muted?: boolean;
+    preload?: 'none' | 'metadata' | 'auto' | '';
+    /** Maps to `crossorigin` */
+    crossOrigin?: 'anonymous' | 'use-credentials' | '';
+}
+
+interface PHPXBaseAttributes extends PHPXHTMLAttributes {
+    href?: string;
+    target?: string;
+}
+
+interface PHPXBlockquoteAttributes extends PHPXHTMLAttributes {
+    cite?: string;
+}
+
+interface PHPXButtonAttributes extends PHPXHTMLAttributes {
+    type?: 'button' | 'submit' | 'reset';
+    disabled?: boolean;
+    name?: string;
+    value?: string;
+    form?: string;
+    /** Maps to `formaction` */
+    formAction?: string;
+    /** Maps to `formenctype` */
+    formEncType?: string;
+    /** Maps to `formmethod` */
+    formMethod?: 'get' | 'post';
+    /** Maps to `formnovalidate` */
+    formNoValidate?: boolean;
+    /** Maps to `formtarget` */
+    formTarget?: string;
+    /** Maps to `autofocus` */
+    autoFocus?: boolean;
+    popovertarget?: string;
+    popovertargetaction?: 'hide' | 'show' | 'toggle';
+}
+
+interface PHPXCanvasAttributes extends PHPXHTMLAttributes {
+    width?: number;
+    height?: number;
+}
+
+interface PHPXColAttributes extends PHPXHTMLAttributes {
+    span?: number;
+}
+
+interface PHPXDataAttributes extends PHPXHTMLAttributes {
+    value?: string;
+}
+
+interface PHPXDelInsAttributes extends PHPXHTMLAttributes {
+    cite?: string;
+    /** Maps to `datetime` */
+    dateTime?: string;
+}
+
+interface PHPXDetailsAttributes extends PHPXHTMLAttributes {
+    open?: boolean;
+    name?: string;
+}
+
+interface PHPXDialogAttributes extends PHPXHTMLAttributes {
+    open?: boolean;
+}
+
+interface PHPXEmbedAttributes extends PHPXHTMLAttributes {
+    src?: string;
+    type?: string;
+    width?: number | string;
+    height?: number | string;
+}
+
+interface PHPXFieldsetAttributes extends PHPXHTMLAttributes {
+    disabled?: boolean;
+    form?: string;
+    name?: string;
+}
+
+interface PHPXFormAttributes extends PHPXHTMLAttributes {
+    action?: string;
+    method?: 'get' | 'post' | 'dialog';
+    /** Maps to `enctype` */
+    encType?: 'application/x-www-form-urlencoded' | 'multipart/form-data' | 'text/plain';
+    /** Maps to `novalidate` */
+    noValidate?: boolean;
+    /** Maps to `autocomplete` */
+    autoComplete?: 'on' | 'off' | (string & {});
+    target?: '_blank' | '_self' | '_parent' | '_top' | (string & {});
+    name?: string;
+    rel?: string;
+    acceptCharset?: string;
+}
+
+interface PHPXHtmlAttributes extends PHPXHTMLAttributes {
+    lang?: string;
+    xmlns?: string;
+}
+
+interface PHPXIframeAttributes extends PHPXHTMLAttributes {
+    src?: string;
+    /** Maps to `srcdoc` */
+    srcDoc?: string;
+    name?: string;
+    allow?: string;
+    width?: number | string;
+    height?: number | string;
+    loading?: 'eager' | 'lazy';
+    sandbox?: string;
+    referrerPolicy?: ReferrerPolicy;
+    /** Maps to `allowfullscreen` */
+    allowFullScreen?: boolean;
+}
+
+interface PHPXImageAttributes extends PHPXHTMLAttributes {
+    src?: string;
+    alt?: string;
+    width?: number | string;
+    height?: number | string;
+    loading?: 'eager' | 'lazy';
+    decoding?: 'sync' | 'async' | 'auto';
+    /** Maps to `crossorigin` */
+    crossOrigin?: 'anonymous' | 'use-credentials' | '';
+    referrerPolicy?: ReferrerPolicy;
+    /** Maps to `srcset` */
+    srcSet?: string;
+    sizes?: string;
+    /** Maps to `usemap` */
+    useMap?: string;
+    /** Maps to `ismap` */
+    isMap?: boolean;
+    fetchPriority?: 'high' | 'low' | 'auto';
+}
+
+interface PHPXInputAttributes extends PHPXHTMLAttributes {
+    type?: 'text' | 'password' | 'email' | 'number' | 'tel' | 'url' | 'search'
+         | 'date' | 'time' | 'datetime-local' | 'month' | 'week' | 'color'
+         | 'range' | 'file' | 'checkbox' | 'radio' | 'submit' | 'reset'
+         | 'button' | 'image' | 'hidden' | (string & {});
+    value?: string | number;
+    defaultValue?: string | number;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    disabled?: boolean;
+    /** Maps to `readonly` */
+    readOnly?: boolean;
+    required?: boolean;
+    placeholder?: string;
+    name?: string;
+    form?: string;
+    /** Maps to `autofocus` */
+    autoFocus?: boolean;
+    /** Maps to `autocomplete` */
+    autoComplete?: string;
+    min?: string | number;
+    max?: string | number;
+    step?: string | number;
+    /** Maps to `minlength` */
+    minLength?: number;
+    /** Maps to `maxlength` */
+    maxLength?: number;
+    pattern?: string;
+    multiple?: boolean;
+    accept?: string;
+    capture?: 'user' | 'environment' | boolean;
+    src?: string;
+    alt?: string;
+    width?: number | string;
+    height?: number | string;
+    list?: string;
+    size?: number;
+    /** Maps to `formaction` */
+    formAction?: string;
+    /** Maps to `formenctype` */
+    formEncType?: string;
+    /** Maps to `formmethod` */
+    formMethod?: string;
+    /** Maps to `formnovalidate` */
+    formNoValidate?: boolean;
+    /** Maps to `formtarget` */
+    formTarget?: string;
+    /** Maps to `inputmode` */
+    inputMode?: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
+    popoverTargetAction?: 'hide' | 'show' | 'toggle';
+    popoverTarget?: string;
+    dirname?: string;
+    /** Maps to `enterkeyhint` */
+    enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
+}
+
+interface PHPXLabelAttributes extends PHPXHTMLAttributes {
+    /** Maps to the HTML `for` attribute */
+    htmlFor?: string;
+    form?: string;
+}
+
+interface PHPXLinkAttributes extends PHPXHTMLAttributes {
+    href?: string;
+    rel?: string;
+    type?: string;
+    media?: string;
+    /** Maps to `crossorigin` */
+    crossOrigin?: 'anonymous' | 'use-credentials' | '';
+    referrerPolicy?: ReferrerPolicy;
+    integrity?: string;
+    /** Maps to `hreflang` */
+    hrefLang?: string;
+    sizes?: string;
+    as?: string;
+    disabled?: boolean;
+    fetchPriority?: 'high' | 'low' | 'auto';
+    blocking?: string;
+    color?: string;
+    imagesizes?: string;
+    imagesrcset?: string;
+}
+
+interface PHPXMapAttributes extends PHPXHTMLAttributes {
+    name?: string;
+}
+
+interface PHPXMetaAttributes extends PHPXHTMLAttributes {
+    name?: string;
+    content?: string;
+    /** Maps to `http-equiv` */
+    httpEquiv?: string;
+    charset?: string;
+    media?: string;
+    property?: string;
+}
+
+interface PHPXMeterAttributes extends PHPXHTMLAttributes {
+    value?: number;
+    min?: number;
+    max?: number;
+    low?: number;
+    high?: number;
+    optimum?: number;
+    form?: string;
+}
+
+interface PHPXObjectAttributes extends PHPXHTMLAttributes {
+    data?: string;
+    type?: string;
+    name?: string;
+    /** Maps to `usemap` */
+    useMap?: string;
+    width?: number | string;
+    height?: number | string;
+    form?: string;
+}
+
+interface PHPXOlAttributes extends PHPXHTMLAttributes {
+    reversed?: boolean;
+    start?: number;
+    type?: '1' | 'a' | 'A' | 'i' | 'I';
+}
+
+interface PHPXOptgroupAttributes extends PHPXHTMLAttributes {
+    label?: string;
+    disabled?: boolean;
+}
+
+interface PHPXOptionAttributes extends PHPXHTMLAttributes {
+    value?: string;
+    selected?: boolean;
+    disabled?: boolean;
+    label?: string;
+}
+
+interface PHPXOutputAttributes extends PHPXHTMLAttributes {
+    htmlFor?: string;
+    form?: string;
+    name?: string;
+}
+
+interface PHPXParamAttributes extends PHPXHTMLAttributes {
+    name?: string;
+    value?: string;
+}
+
+interface PHPXProgressAttributes extends PHPXHTMLAttributes {
+    value?: number;
+    max?: number;
+}
+
+interface PHPXScriptAttributes extends PHPXHTMLAttributes {
+    src?: string;
+    type?: string;
+    async?: boolean;
+    defer?: boolean;
+    /** Maps to `crossorigin` */
+    crossOrigin?: 'anonymous' | 'use-credentials' | '';
+    integrity?: string;
+    /** Maps to `nomodule` */
+    noModule?: boolean;
+    referrerPolicy?: ReferrerPolicy;
+    fetchPriority?: 'high' | 'low' | 'auto';
+    blocking?: string;
+    nonce?: string;
+}
+
+interface PHPXSelectAttributes extends PHPXHTMLAttributes {
+    value?: string | string[];
+    defaultValue?: string | string[];
+    disabled?: boolean;
+    required?: boolean;
+    multiple?: boolean;
+    name?: string;
+    form?: string;
+    size?: number;
+    /** Maps to `autofocus` */
+    autoFocus?: boolean;
+    /** Maps to `autocomplete` */
+    autoComplete?: string;
+}
+
+interface PHPXSourceAttributes extends PHPXHTMLAttributes {
+    src?: string;
+    /** Maps to `srcset` */
+    srcSet?: string;
+    type?: string;
+    media?: string;
+    sizes?: string;
+    width?: number;
+    height?: number;
+}
+
+interface PHPXStyleAttributes extends PHPXHTMLAttributes {
+    type?: string;
+    media?: string;
+    nonce?: string;
+    /** @deprecated */
+    scoped?: boolean;
+    blocking?: string;
+}
+
+interface PHPXTableAttributes extends PHPXHTMLAttributes {
+    summary?: string;
+}
+
+interface PHPXTableCellAttributes extends PHPXHTMLAttributes {
+    /** Maps to `colspan` */
+    colSpan?: number;
+    /** Maps to `rowspan` */
+    rowSpan?: number;
+    headers?: string;
+    scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
+    abbr?: string;
+}
+
+interface PHPXTextareaAttributes extends PHPXHTMLAttributes {
+    value?: string;
+    defaultValue?: string;
+    disabled?: boolean;
+    /** Maps to `readonly` */
+    readOnly?: boolean;
+    required?: boolean;
+    placeholder?: string;
+    name?: string;
+    form?: string;
+    rows?: number;
+    cols?: number;
+    /** Maps to `autofocus` */
+    autoFocus?: boolean;
+    /** Maps to `autocomplete` */
+    autoComplete?: string;
+    /** Maps to `minlength` */
+    minLength?: number;
+    /** Maps to `maxlength` */
+    maxLength?: number;
+    wrap?: 'hard' | 'soft' | 'off';
+    /** Maps to `inputmode` */
+    inputMode?: string;
+    /** Maps to `enterkeyhint` */
+    enterKeyHint?: string;
+    dirname?: string;
+}
+
+interface PHPXTimeAttributes extends PHPXHTMLAttributes {
+    /** Maps to `datetime` */
+    dateTime?: string;
+}
+
+interface PHPXTrackAttributes extends PHPXHTMLAttributes {
+    src?: string;
+    kind?: 'subtitles' | 'captions' | 'descriptions' | 'chapters' | 'metadata';
+    srclang?: string;
+    label?: string;
+    default?: boolean;
+}
+
+interface PHPXVideoAttributes extends PHPXHTMLAttributes {
+    src?: string;
+    width?: number | string;
+    height?: number | string;
+    poster?: string;
+    /** Maps to `autoplay` */
+    autoPlay?: boolean;
+    controls?: boolean;
+    loop?: boolean;
+    muted?: boolean;
+    preload?: 'none' | 'metadata' | 'auto' | '';
+    /** Maps to `crossorigin` */
+    crossOrigin?: 'anonymous' | 'use-credentials' | '';
+    /** Maps to `playsinline` */
+    playsInline?: boolean;
+    disablePictureInPicture?: boolean;
+    controlsList?: string;
+    disableRemotePlayback?: boolean;
+}
+
+// ─── SVG attribute interfaces ──────────────────────────────────────────────────
+
+interface PHPXSvgAttributes extends PHPXHTMLAttributes {
+    viewBox?: string;
+    xmlns?: string;
+    width?: number | string;
+    height?: number | string;
+    fill?: string;
+    stroke?: string;
+    strokeWidth?: number | string;
+    strokeLinecap?: 'butt' | 'round' | 'square';
+    strokeLinejoin?: 'miter' | 'round' | 'bevel';
+    opacity?: number | string;
+    transform?: string;
+    preserveAspectRatio?: string;
+}
+
+interface PHPXSvgPathAttributes extends PHPXHTMLAttributes {
+    d?: string;
+    fill?: string;
+    stroke?: string;
+    strokeWidth?: number | string;
+    opacity?: number | string;
+    transform?: string;
+    fillRule?: 'nonzero' | 'evenodd';
+    clipRule?: 'nonzero' | 'evenodd';
+}
+
+interface PHPXSvgShapeAttributes extends PHPXHTMLAttributes {
+    fill?: string;
+    stroke?: string;
+    strokeWidth?: number | string;
+    opacity?: number | string;
+    transform?: string;
+}
+
+// ─── Complete intrinsic elements map ──────────────────────────────────────────
+
+interface PHPXIntrinsicElements {
+    // ── Document structure ──────────────────────────────────────────────────
+    html: PHPXHtmlAttributes;
+    head: PHPXHTMLAttributes;
+    body: PHPXHTMLAttributes;
+    title: PHPXHTMLAttributes;
+
+    // ── Metadata ────────────────────────────────────────────────────────────
+    base: PHPXBaseAttributes;
+    link: PHPXLinkAttributes;
+    meta: PHPXMetaAttributes;
+    style: PHPXStyleAttributes;
+
+    // ── Sectioning ──────────────────────────────────────────────────────────
+    header: PHPXHTMLAttributes;
+    footer: PHPXHTMLAttributes;
+    main: PHPXHTMLAttributes;
+    nav: PHPXHTMLAttributes;
+    aside: PHPXHTMLAttributes;
+    article: PHPXHTMLAttributes;
+    section: PHPXHTMLAttributes;
+    address: PHPXHTMLAttributes;
+    hgroup: PHPXHTMLAttributes;
+    search: PHPXHTMLAttributes;
+
+    // ── Headings ────────────────────────────────────────────────────────────
+    h1: PHPXHTMLAttributes;
+    h2: PHPXHTMLAttributes;
+    h3: PHPXHTMLAttributes;
+    h4: PHPXHTMLAttributes;
+    h5: PHPXHTMLAttributes;
+    h6: PHPXHTMLAttributes;
+
+    // ── Grouping content ────────────────────────────────────────────────────
+    div: PHPXHTMLAttributes;
+    p: PHPXHTMLAttributes;
+    blockquote: PHPXBlockquoteAttributes;
+    pre: PHPXHTMLAttributes;
+    ol: PHPXOlAttributes;
+    ul: PHPXHTMLAttributes;
+    li: PHPXHTMLAttributes;
+    dl: PHPXHTMLAttributes;
+    dt: PHPXHTMLAttributes;
+    dd: PHPXHTMLAttributes;
+    figure: PHPXHTMLAttributes;
+    figcaption: PHPXHTMLAttributes;
+    hr: PHPXHTMLAttributes;
+    menu: PHPXHTMLAttributes;
+
+    // ── Text content ────────────────────────────────────────────────────────
+    a: PHPXAnchorAttributes;
+    abbr: PHPXHTMLAttributes;
+    b: PHPXHTMLAttributes;
+    bdi: PHPXHTMLAttributes;
+    bdo: PHPXHTMLAttributes;
+    br: PHPXHTMLAttributes;
+    cite: PHPXHTMLAttributes;
+    code: PHPXHTMLAttributes;
+    data: PHPXDataAttributes;
+    del: PHPXDelInsAttributes;
+    dfn: PHPXHTMLAttributes;
+    em: PHPXHTMLAttributes;
+    i: PHPXHTMLAttributes;
+    ins: PHPXDelInsAttributes;
+    kbd: PHPXHTMLAttributes;
+    mark: PHPXHTMLAttributes;
+    q: PHPXBlockquoteAttributes;
+    rp: PHPXHTMLAttributes;
+    rt: PHPXHTMLAttributes;
+    ruby: PHPXHTMLAttributes;
+    s: PHPXHTMLAttributes;
+    samp: PHPXHTMLAttributes;
+    small: PHPXHTMLAttributes;
+    span: PHPXHTMLAttributes;
+    strong: PHPXHTMLAttributes;
+    sub: PHPXHTMLAttributes;
+    sup: PHPXHTMLAttributes;
+    time: PHPXTimeAttributes;
+    u: PHPXHTMLAttributes;
+    var: PHPXHTMLAttributes;
+    wbr: PHPXHTMLAttributes;
+
+    // ── Embedded content ────────────────────────────────────────────────────
+    img: PHPXImageAttributes;
+    audio: PHPXAudioAttributes;
+    video: PHPXVideoAttributes;
+    track: PHPXTrackAttributes;
+    picture: PHPXHTMLAttributes;
+    source: PHPXSourceAttributes;
+    canvas: PHPXCanvasAttributes;
+    map: PHPXMapAttributes;
+    area: PHPXAreaAttributes;
+    iframe: PHPXIframeAttributes;
+    embed: PHPXEmbedAttributes;
+    object: PHPXObjectAttributes;
+    param: PHPXParamAttributes;
+
+    // ── Scripting ───────────────────────────────────────────────────────────
+    script: PHPXScriptAttributes;
+    noscript: PHPXHTMLAttributes;
+    template: PHPXHTMLAttributes;
+    slot: PHPXHTMLAttributes;
+
+    // ── Tables ──────────────────────────────────────────────────────────────
+    table: PHPXTableAttributes;
+    caption: PHPXHTMLAttributes;
+    colgroup: PHPXHTMLAttributes;
+    col: PHPXColAttributes;
+    thead: PHPXHTMLAttributes;
+    tbody: PHPXHTMLAttributes;
+    tfoot: PHPXHTMLAttributes;
+    tr: PHPXHTMLAttributes;
+    th: PHPXTableCellAttributes;
+    td: PHPXTableCellAttributes;
+
+    // ── Forms ───────────────────────────────────────────────────────────────
+    form: PHPXFormAttributes;
+    input: PHPXInputAttributes;
+    textarea: PHPXTextareaAttributes;
+    select: PHPXSelectAttributes;
+    option: PHPXOptionAttributes;
+    optgroup: PHPXOptgroupAttributes;
+    button: PHPXButtonAttributes;
+    label: PHPXLabelAttributes;
+    fieldset: PHPXFieldsetAttributes;
+    legend: PHPXHTMLAttributes;
+    datalist: PHPXHTMLAttributes;
+    output: PHPXOutputAttributes;
+    progress: PHPXProgressAttributes;
+    meter: PHPXMeterAttributes;
+
+    // ── Interactive ─────────────────────────────────────────────────────────
+    details: PHPXDetailsAttributes;
+    summary: PHPXHTMLAttributes;
+    dialog: PHPXDialogAttributes;
+
+    // ── SVG (basic) ─────────────────────────────────────────────────────────
+    svg: PHPXSvgAttributes;
+    path: PHPXSvgPathAttributes;
+    rect: PHPXSvgShapeAttributes & {
+        x?: number | string; y?: number | string;
+        width?: number | string; height?: number | string;
+        rx?: number | string; ry?: number | string;
+    };
+    circle: PHPXSvgShapeAttributes & {
+        cx?: number | string; cy?: number | string; r?: number | string;
+    };
+    ellipse: PHPXSvgShapeAttributes & {
+        cx?: number | string; cy?: number | string;
+        rx?: number | string; ry?: number | string;
+    };
+    line: PHPXSvgShapeAttributes & {
+        x1?: number | string; y1?: number | string;
+        x2?: number | string; y2?: number | string;
+    };
+    polyline: PHPXSvgShapeAttributes & { points?: string };
+    polygon: PHPXSvgShapeAttributes & { points?: string };
+    text: PHPXSvgShapeAttributes & {
+        x?: number | string; y?: number | string;
+        dx?: number | string; dy?: number | string;
+        textAnchor?: 'start' | 'middle' | 'end';
+        dominantBaseline?: string;
+    };
+    tspan: PHPXSvgShapeAttributes & {
+        x?: number | string; y?: number | string;
+        dx?: number | string; dy?: number | string;
+    };
+    use: PHPXHTMLAttributes & { href?: string; x?: number | string; y?: number | string };
+    defs: PHPXHTMLAttributes;
+    g: PHPXSvgShapeAttributes & { transform?: string };
+    clipPath: PHPXHTMLAttributes & { clipPathUnits?: string };
+    mask: PHPXHTMLAttributes;
+    symbol: PHPXSvgAttributes;
+    linearGradient: PHPXHTMLAttributes & {
+        x1?: string; y1?: string; x2?: string; y2?: string;
+        gradientUnits?: 'userSpaceOnUse' | 'objectBoundingBox';
+        gradientTransform?: string;
+    };
+    radialGradient: PHPXHTMLAttributes & {
+        cx?: string; cy?: string; r?: string; fx?: string; fy?: string;
+        gradientUnits?: 'userSpaceOnUse' | 'objectBoundingBox';
+    };
+    stop: PHPXHTMLAttributes & { offset?: string | number; stopColor?: string; stopOpacity?: number | string };
+    pattern: PHPXHTMLAttributes & {
+        x?: string; y?: string; width?: string; height?: string;
+        patternUnits?: string; patternTransform?: string;
+    };
+    image: PHPXHTMLAttributes & { href?: string; x?: string; y?: string; width?: string; height?: string };
+    foreignObject: PHPXHTMLAttributes & { x?: string; y?: string; width?: string; height?: string };
+
+    // ── Custom elements / web components — catch-all ─────────────────────────
+    [tagName: string]: PHPXHTMLAttributes;
+}

--- a/src/compiler/AbstractCompilerPlugin.php
+++ b/src/compiler/AbstractCompilerPlugin.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Attitude\PHPX\Compiler;
+
+/**
+ * Convenience base class for compiler plugins.
+ *
+ * All visitor methods return null by default, so you only need to override
+ * the methods relevant to your plugin.
+ */
+abstract class AbstractCompilerPlugin implements CompilerPlugin
+{
+    public function visitElement(
+        string $nameText,
+        ?string $compiledAttributes,
+        ?string $compiledChildren,
+        FormatterInterface $formatter,
+    ): ?string {
+        return null;
+    }
+
+    public function visitFragment(
+        string $compiledChildren,
+        FormatterInterface $formatter,
+    ): ?string {
+        return null;
+    }
+
+    public function visitAttribute(
+        string $nameText,
+        string $compiledValue,
+        FormatterInterface $formatter,
+    ): ?string {
+        return null;
+    }
+}

--- a/src/compiler/Compiler.php
+++ b/src/compiler/Compiler.php
@@ -3,6 +3,7 @@
 namespace Attitude\PHPX\Compiler;
 
 use Attitude\PHPX\Compiler\Formatter;
+use Attitude\PHPX\Compiler\CompilerPlugin;
 use Attitude\PHPX\Parser\NodeType;
 use Attitude\PHPX\Parser\Parser;
 use Attitude\PHPX\Parser\Token;
@@ -13,6 +14,8 @@ final class Compiler {
 	private TokensList $tokens;
 	private Parser $parser;
 	private FormatterInterface $formatter;
+	/** @var CompilerPlugin[] */
+	private array $plugins;
 	private string $source;
 	private array $ast;
 	private string $compiled;
@@ -20,10 +23,12 @@ final class Compiler {
 	public function __construct(
 		?Parser $parser = null,
 		?FormatterInterface $formatter = null,
+		array $plugins = [],
 		private ?LoggerInterface $logger = null,
 	) {
 		$this->parser = $parser ?? new Parser(logger: $this->logger);
 		$this->formatter = $formatter ?? new Formatter();
+		$this->plugins = $plugins;
 	}
 
 	public function compile(string $source): string {
@@ -88,9 +93,16 @@ final class Compiler {
 		$this->logger?->debug('compilePHPXFragmentElement', $node);
 		assert($node['$$type'] === NodeType::PHPX_FRAGMENT);
 
-		return $this->formatter->formatFragment(
-			$this->compilePHPXChildrenArray($node['children'])
-		);
+		$compiledChildren = $this->compilePHPXChildrenArray($node['children']);
+
+		foreach ($this->plugins as $plugin) {
+			$result = $plugin->visitFragment($compiledChildren, $this->formatter);
+			if ($result !== null) {
+				return $result;
+			}
+		}
+
+		return $this->formatter->formatFragment($compiledChildren);
 	}
 
 	private function compilePHPXAttribute(array $node): string {
@@ -109,18 +121,25 @@ final class Compiler {
 
 		if (!$assignment) {
 			assert($value === true);
-			return $this->formatter->formatAttributeExpression($nameText, 'true');
+			$compiledValue = 'true';
 		} else if ($assignment->text === '=') {
 			if ($value instanceof Token) {
-				return $this->formatter->formatAttributeExpression($nameText, $value->text);
+				$compiledValue = $value->text;
 			} else {
-				$expression = $this->compileBlock($value, '(', ')');
-
-				return $this->formatter->formatAttributeExpression($nameText, $expression);
+				$compiledValue = $this->compileBlock($value, '(', ')');
 			}
 		} else {
 			throw new \RuntimeException("Unknown assignment type: {$assignment->text}");
 		}
+
+		foreach ($this->plugins as $plugin) {
+			$result = $plugin->visitAttribute($nameText, $compiledValue, $this->formatter);
+			if ($result !== null) {
+				return $result;
+			}
+		}
+
+		return $this->formatter->formatAttributeExpression($nameText, $compiledValue);
 	}
 
 	private function compilePHPXAttributesPropsExpression(array $node): string {
@@ -136,6 +155,13 @@ final class Compiler {
 				// Prop punning:
 				if ($child->id === T_VARIABLE) {
 					$attribute = strtolower(substr($child->text, 1));
+
+					foreach ($this->plugins as $plugin) {
+						$result = $plugin->visitAttribute($attribute, $child->text, $this->formatter);
+						if ($result !== null) {
+							return $result;
+						}
+					}
 
 					return $this->formatter->formatAttributeExpression($attribute, $child->text);
 				} else {
@@ -184,11 +210,26 @@ final class Compiler {
 			? implode('', array_map(fn(Token $t) => $t->text, $name))
 			: $name->text;
 
-		return $this->formatter->formatElement(
-			$nameText,
-			(!empty($attributes) ? $this->compilePHPXAttributes($attributes) : null),
-			(!empty($children) ? $this->compilePHPXChildrenArray($children) : null),
-		);
+		$compiledAttributes = !empty($attributes) ? $this->compilePHPXAttributes($attributes) : null;
+		$compiledChildren = !empty($children) ? $this->compilePHPXChildrenArray($children) : null;
+
+		// Normalise '[]' (whitespace-only attributes/children) to null — the
+		// formatter already treats these as empty; plugins should see the same.
+		if ($compiledAttributes === '[]') {
+			$compiledAttributes = null;
+		}
+		if ($compiledChildren === '[]') {
+			$compiledChildren = null;
+		}
+
+		foreach ($this->plugins as $plugin) {
+			$result = $plugin->visitElement($nameText, $compiledAttributes, $compiledChildren, $this->formatter);
+			if ($result !== null) {
+				return $result;
+			}
+		}
+
+		return $this->formatter->formatElement($nameText, $compiledAttributes, $compiledChildren);
 	}
 
 	private static function concatenateStringMembers(array $array): array {

--- a/src/compiler/Compiler.php
+++ b/src/compiler/Compiler.php
@@ -23,8 +23,8 @@ final class Compiler {
 	public function __construct(
 		?Parser $parser = null,
 		?FormatterInterface $formatter = null,
-		array $plugins = [],
 		private ?LoggerInterface $logger = null,
+		array $plugins = [],
 	) {
 		$this->parser = $parser ?? new Parser(logger: $this->logger);
 		$this->formatter = $formatter ?? new Formatter();

--- a/src/compiler/CompilerPlugin.php
+++ b/src/compiler/CompilerPlugin.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Attitude\PHPX\Compiler;
+
+/**
+ * Visitor-style plugin for the PHPX compiler.
+ *
+ * Plugins intercept element, fragment, and attribute compilation after attributes
+ * and children have already been compiled into PHP strings by the Compiler. Return
+ * a non-null string to override the output; return null to fall through to the next
+ * plugin or, ultimately, the active FormatterInterface.
+ *
+ * Plugins are tried in registration order; the first non-null return wins.
+ *
+ * Example — intercept a custom <slot> element:
+ *
+ *   class SlotPlugin extends AbstractCompilerPlugin {
+ *       public function visitElement(
+ *           string $nameText,
+ *           ?string $compiledAttributes,
+ *           ?string $compiledChildren,
+ *           FormatterInterface $formatter,
+ *       ): ?string {
+ *           if ($nameText !== 'slot') return null;
+ *           $name = '...'; // extract from $compiledAttributes if needed
+ *           return "renderSlot({$name}, {$compiledChildren})";
+ *       }
+ *   }
+ */
+interface CompilerPlugin
+{
+    /**
+     * Called for every PHPX element node.
+     *
+     * @param string $nameText Tag name as it appears in source (e.g. 'div', 'MyComponent').
+     * @param string|null $compiledAttributes Already-compiled PHP props array, or null when the
+     *   element has no attributes.
+     * @param string|null $compiledChildren Already-compiled PHP children array, or null when the
+     *   element has no children.
+     * @param FormatterInterface $formatter The active formatter — use it to delegate for elements
+     *   you don't handle.
+     * @return string|null Compiled PHP string, or null to defer.
+     */
+    public function visitElement(
+        string $nameText,
+        ?string $compiledAttributes,
+        ?string $compiledChildren,
+        FormatterInterface $formatter,
+    ): ?string;
+
+    /**
+     * Called for every PHPX fragment node (<>…</>).
+     *
+     * @param string $compiledChildren Already-compiled PHP children array.
+     * @param FormatterInterface $formatter The active formatter.
+     * @return string|null Compiled PHP string, or null to defer.
+     */
+    public function visitFragment(
+        string $compiledChildren,
+        FormatterInterface $formatter,
+    ): ?string;
+
+    /**
+     * Called for every PHPX attribute node.
+     *
+     * @param string $nameText Attribute name as it appears in source (e.g. 'className', 'x-if').
+     * @param string $compiledValue Already-compiled PHP value expression.
+     * @param FormatterInterface $formatter The active formatter.
+     * @return string|null Compiled PHP string (the full 'key' => value pair), or null to defer.
+     */
+    public function visitAttribute(
+        string $nameText,
+        string $compiledValue,
+        FormatterInterface $formatter,
+    ): ?string;
+}

--- a/src/compiler/index.php
+++ b/src/compiler/index.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types = 1);
 
+require_once 'CompilerPlugin.php';
+require_once 'AbstractCompilerPlugin.php';
 require_once 'Compiler.php';
 require_once 'FormatterInterface.php';
 require_once 'Formatter.php';

--- a/src/language-server/CompletionExtension.php
+++ b/src/language-server/CompletionExtension.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Attitude\PHPX\LanguageServer;
+
+/**
+ * LSP completion extension.
+ *
+ * Implementations return additional completion items that are merged with the
+ * built-in items produced by CompletionProvider. All registered extensions are
+ * always called; their results are concatenated.
+ *
+ * Example — add completions for a custom <x-icon> component library:
+ *
+ *   class IconCompletionExtension implements CompletionExtension {
+ *       public function complete(TextDocumentItem $document, int $line, int $character): array {
+ *           return [
+ *               ['label' => 'x-icon', 'kind' => 14, 'detail' => 'Icon component'],
+ *           ];
+ *       }
+ *
+ *       public function getCapabilities(): array {
+ *           return ['triggerCharacters' => ['x']];
+ *       }
+ *   }
+ */
+interface CompletionExtension
+{
+    /**
+     * Return LSP CompletionItem objects to append to the built-in completion list.
+     *
+     * @param TextDocumentItem $document The document being edited.
+     * @param int $line Zero-based line number of the cursor.
+     * @param int $character Zero-based character offset of the cursor.
+     * @return array[] Array of LSP CompletionItem arrays.
+     */
+    public function complete(TextDocumentItem $document, int $line, int $character): array;
+
+    /**
+     * Return LSP completionProvider capability overrides to merge into the server capabilities.
+     *
+     * Recognised keys:
+     *   - 'triggerCharacters' (string[]) — merged (deduplicated) with the built-in trigger chars.
+     *
+     * @return array Partial completionProvider capability map.
+     */
+    public function getCapabilities(): array;
+}

--- a/src/language-server/DiagnosticsExtension.php
+++ b/src/language-server/DiagnosticsExtension.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Attitude\PHPX\LanguageServer;
+
+/**
+ * LSP diagnostics extension.
+ *
+ * Implementations return additional diagnostics that are merged with the
+ * built-in diagnostics produced by DiagnosticsProvider. All registered
+ * extensions are always called; their results are concatenated.
+ *
+ * Example — warn on deprecated attribute usage:
+ *
+ *   class DeprecatedAttrDiagnosticsExtension implements DiagnosticsExtension {
+ *       public function diagnose(TextDocumentItem $document): array {
+ *           $diagnostics = [];
+ *           // ... scan $document->text for deprecated attributes ...
+ *           return $diagnostics;
+ *       }
+ *   }
+ */
+interface DiagnosticsExtension
+{
+    /**
+     * Return LSP Diagnostic objects to append to the built-in diagnostics list.
+     *
+     * @param TextDocumentItem $document The document to analyse.
+     * @return array[] Array of LSP Diagnostic arrays.
+     */
+    public function diagnose(TextDocumentItem $document): array;
+}

--- a/src/language-server/HoverExtension.php
+++ b/src/language-server/HoverExtension.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Attitude\PHPX\LanguageServer;
+
+/**
+ * LSP hover extension.
+ *
+ * Implementations are tried in registration order before the built-in
+ * HoverProvider. Return a non-null LSP Hover object to provide the hover
+ * content; return null to fall through to the next extension or the
+ * built-in provider.
+ *
+ * Example — add hover docs for a custom attribute:
+ *
+ *   class XIfHoverExtension implements HoverExtension {
+ *       public function hover(TextDocumentItem $document, int $line, int $character): ?array {
+ *           $word = // ... detect 'x-if' at position ...
+ *           if ($word !== 'x-if') return null;
+ *           return [
+ *               'contents' => ['kind' => 'markdown', 'value' => '**`x-if`** — conditional rendering'],
+ *               'range' => [...],
+ *           ];
+ *       }
+ *   }
+ */
+interface HoverExtension
+{
+    /**
+     * Return an LSP Hover object if this extension handles the cursor position,
+     * or null to fall through to the next extension / built-in provider.
+     *
+     * @param TextDocumentItem $document The document being hovered.
+     * @param int $line Zero-based line number of the cursor.
+     * @param int $character Zero-based character offset of the cursor.
+     * @return array|null LSP Hover array, or null to defer.
+     */
+    public function hover(TextDocumentItem $document, int $line, int $character): ?array;
+}

--- a/src/language-server/Server.php
+++ b/src/language-server/Server.php
@@ -146,8 +146,12 @@ final class Server
 
         $triggerCharacters = ['<', '/', ' '];
         foreach ($this->completionExtensions as $ext) {
-            $extChars = $ext->getCapabilities()['triggerCharacters'] ?? [];
-            $triggerCharacters = array_values(array_unique(array_merge($triggerCharacters, $extChars)));
+            try {
+                $extChars = $ext->getCapabilities()['triggerCharacters'] ?? [];
+                $triggerCharacters = array_values(array_unique(array_merge($triggerCharacters, $extChars)));
+            } catch (\Throwable $e) {
+                $this->logger?->error('CompletionExtension::getCapabilities() failed', ['exception' => $e]);
+            }
         }
 
         $capabilities = [
@@ -292,7 +296,11 @@ final class Server
         $items = $this->completion->complete($document, $line, $character);
 
         foreach ($this->completionExtensions as $ext) {
-            $items = array_merge($items, $ext->complete($document, $line, $character));
+            try {
+                $items = array_merge($items, $ext->complete($document, $line, $character));
+            } catch (\Throwable $e) {
+                $this->logger?->error('CompletionExtension::complete() failed', ['exception' => $e]);
+            }
         }
 
         return $items;
@@ -313,9 +321,13 @@ final class Server
         }
 
         foreach ($this->hoverExtensions as $ext) {
-            $result = $ext->hover($document, $line, $character);
-            if ($result !== null) {
-                return $result;
+            try {
+                $result = $ext->hover($document, $line, $character);
+                if ($result !== null) {
+                    return $result;
+                }
+            } catch (\Throwable $e) {
+                $this->logger?->error('HoverExtension::hover() failed', ['exception' => $e]);
             }
         }
 
@@ -370,7 +382,11 @@ final class Server
         $diagnostics = $this->diagnostics->diagnose($document);
 
         foreach ($this->diagnosticsExtensions as $ext) {
-            $diagnostics = array_merge($diagnostics, $ext->diagnose($document));
+            try {
+                $diagnostics = array_merge($diagnostics, $ext->diagnose($document));
+            } catch (\Throwable $e) {
+                $this->logger?->error('DiagnosticsExtension::diagnose() failed', ['exception' => $e]);
+            }
         }
 
         $this->transport->write(Message::notification('textDocument/publishDiagnostics', [

--- a/src/language-server/Server.php
+++ b/src/language-server/Server.php
@@ -16,10 +16,19 @@ final class Server
     private bool $running = false;
     private bool $shutdownRequested = false;
     private ?LoggerInterface $logger;
+    /** @var CompletionExtension[] */
+    private array $completionExtensions;
+    /** @var HoverExtension[] */
+    private array $hoverExtensions;
+    /** @var DiagnosticsExtension[] */
+    private array $diagnosticsExtensions;
 
     public function __construct(
         ?Transport $transport = null,
         ?LoggerInterface $logger = null,
+        array $completionExtensions = [],
+        array $hoverExtensions = [],
+        array $diagnosticsExtensions = [],
     ) {
         $this->transport = $transport ?? new Transport();
         $this->logger = $logger;
@@ -28,6 +37,9 @@ final class Server
         $this->completion = new CompletionProvider();
         $this->hover = new HoverProvider();
         $this->rename = new RenameProvider();
+        $this->completionExtensions = $completionExtensions;
+        $this->hoverExtensions = $hoverExtensions;
+        $this->diagnosticsExtensions = $diagnosticsExtensions;
     }
 
     public function run(): void
@@ -132,6 +144,12 @@ final class Server
         }
         $positionEncoding = in_array('utf-8', $clientEncodings, true) ? 'utf-8' : null;
 
+        $triggerCharacters = ['<', '/', ' '];
+        foreach ($this->completionExtensions as $ext) {
+            $extChars = $ext->getCapabilities()['triggerCharacters'] ?? [];
+            $triggerCharacters = array_values(array_unique(array_merge($triggerCharacters, $extChars)));
+        }
+
         $capabilities = [
             'textDocumentSync' => [
                 'openClose' => true,
@@ -139,7 +157,7 @@ final class Server
                 'save' => ['includeText' => true],
             ],
             'completionProvider' => [
-                'triggerCharacters' => ['<', '/', ' '],
+                'triggerCharacters' => $triggerCharacters,
                 'resolveProvider' => false,
             ],
             'hoverProvider' => true,
@@ -271,7 +289,13 @@ final class Server
             return [];
         }
 
-        return $this->completion->complete($document, $line, $character);
+        $items = $this->completion->complete($document, $line, $character);
+
+        foreach ($this->completionExtensions as $ext) {
+            $items = array_merge($items, $ext->complete($document, $line, $character));
+        }
+
+        return $items;
     }
 
     private function handleHover(array $params): ?array
@@ -286,6 +310,13 @@ final class Server
 
         if ($document === null) {
             return null;
+        }
+
+        foreach ($this->hoverExtensions as $ext) {
+            $result = $ext->hover($document, $line, $character);
+            if ($result !== null) {
+                return $result;
+            }
         }
 
         return $this->hover->hover($document, $line, $character);
@@ -337,6 +368,10 @@ final class Server
         }
 
         $diagnostics = $this->diagnostics->diagnose($document);
+
+        foreach ($this->diagnosticsExtensions as $ext) {
+            $diagnostics = array_merge($diagnostics, $ext->diagnose($document));
+        }
 
         $this->transport->write(Message::notification('textDocument/publishDiagnostics', [
             'uri' => $uri,

--- a/tests/compiler/CompilerPlugin.spec.php
+++ b/tests/compiler/CompilerPlugin.spec.php
@@ -1,0 +1,200 @@
+<?php declare(strict_types=1);
+
+namespace Attitude\PHPX;
+
+use Attitude\PHPX\Compiler\AbstractCompilerPlugin;
+use Attitude\PHPX\Compiler\Compiler;
+use Attitude\PHPX\Compiler\CompilerPlugin;
+use Attitude\PHPX\Compiler\FormatterInterface;
+
+require_once __DIR__ . '/../../src/index.php';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Plugin that overrides <slot> elements with a custom renderSlot() call. */
+function makeSlotPlugin(): CompilerPlugin {
+    return new class extends AbstractCompilerPlugin {
+        public function visitElement(
+            string $nameText,
+            ?string $compiledAttributes,
+            ?string $compiledChildren,
+            FormatterInterface $formatter,
+        ): ?string {
+            if ($nameText !== 'slot') return null;
+            $parts = array_filter([$compiledAttributes, $compiledChildren]);
+            return 'renderSlot(' . implode(', ', $parts) . ')';
+        }
+    };
+}
+
+/** Plugin that overrides <> fragments with a custom fragment() call. */
+function makeFragmentPlugin(): CompilerPlugin {
+    return new class extends AbstractCompilerPlugin {
+        public function visitFragment(
+            string $compiledChildren,
+            FormatterInterface $formatter,
+        ): ?string {
+            return 'fragment(' . $compiledChildren . ')';
+        }
+    };
+}
+
+/** Plugin that intercepts the x-if attribute and emits a raw PHP value. */
+function makeXIfAttributePlugin(): CompilerPlugin {
+    return new class extends AbstractCompilerPlugin {
+        public function visitAttribute(
+            string $nameText,
+            string $compiledValue,
+            FormatterInterface $formatter,
+        ): ?string {
+            if ($nameText !== 'x-if') return null;
+            return "'__xif__' => {$compiledValue}";
+        }
+    };
+}
+
+// ── Element visitor tests ─────────────────────────────────────────────────────
+
+describe('CompilerPlugin — element visitor', function () {
+    it('intercepts a specific element and returns custom output', function () {
+        $compiler = new Compiler(plugins: [makeSlotPlugin()]);
+        $result = $compiler->compile('<slot />');
+        expect($result)->toBe('renderSlot()');
+    });
+
+    it('passes compiled attributes to the plugin', function () {
+        $compiler = new Compiler(plugins: [makeSlotPlugin()]);
+        $result = $compiler->compile('<slot name="header" />');
+        expect($result)->toContain('renderSlot(');
+        expect($result)->toContain("'name'=>\"header\"");
+    });
+
+    it('passes compiled children to the plugin', function () {
+        $compiler = new Compiler(plugins: [makeSlotPlugin()]);
+        $result = $compiler->compile('<slot>default</slot>');
+        expect($result)->toContain('renderSlot(');
+        expect($result)->toContain("'default'");
+    });
+
+    it('returns null to fall through to the formatter for unhandled elements', function () {
+        $compiler = new Compiler(plugins: [makeSlotPlugin()]);
+        $result = $compiler->compile('<div />');
+        // Default formatter output for <div />
+        expect($result)->toBe("['$', 'div']");
+    });
+
+    it('first matching plugin wins; remaining plugins are not consulted', function () {
+        $calls = [];
+
+        $first = new class($calls) extends AbstractCompilerPlugin {
+            public function __construct(private array &$calls) {}
+            public function visitElement(string $nameText, ?string $ca, ?string $cc, FormatterInterface $f): ?string {
+                $this->calls[] = 'first';
+                return 'first-wins';
+            }
+        };
+
+        $second = new class($calls) extends AbstractCompilerPlugin {
+            public function __construct(private array &$calls) {}
+            public function visitElement(string $nameText, ?string $ca, ?string $cc, FormatterInterface $f): ?string {
+                $this->calls[] = 'second';
+                return 'second-wins';
+            }
+        };
+
+        $compiler = new Compiler(plugins: [$first, $second]);
+        $result = $compiler->compile('<div />');
+
+        expect($result)->toBe('first-wins');
+        expect($calls)->toBe(['first']);
+    });
+
+    it('falls through all plugins and uses the formatter when all return null', function () {
+        $noOp = new class extends AbstractCompilerPlugin {};
+
+        $compiler = new Compiler(plugins: [$noOp, $noOp]);
+        $result = $compiler->compile('<span />');
+        expect($result)->toBe("['$', 'span']");
+    });
+});
+
+// ── Fragment visitor tests ────────────────────────────────────────────────────
+
+describe('CompilerPlugin — fragment visitor', function () {
+    it('intercepts a fragment and returns custom output', function () {
+        $compiler = new Compiler(plugins: [makeFragmentPlugin()]);
+        $result = $compiler->compile('<>Hello</>');
+        expect($result)->toBe("fragment(['Hello'])");
+    });
+
+    it('returns null to fall through to the formatter for fragments', function () {
+        $compiler = new Compiler(plugins: [makeSlotPlugin()]); // slot plugin ignores fragments
+        $result = $compiler->compile('<>Hello</>');
+        // Default formatter output
+        expect($result)->toBe("['Hello']");
+    });
+});
+
+// ── Attribute visitor tests ───────────────────────────────────────────────────
+
+describe('CompilerPlugin — attribute visitor', function () {
+    it('intercepts a specific attribute and returns custom output', function () {
+        $compiler = new Compiler(plugins: [makeXIfAttributePlugin()]);
+        $result = $compiler->compile('<div x-if={$show} />');
+        expect($result)->toContain("'__xif__' => (\$show)");
+    });
+
+    it('leaves unhandled attributes to the formatter', function () {
+        $compiler = new Compiler(plugins: [makeXIfAttributePlugin()]);
+        $result = $compiler->compile('<div className="foo" />');
+        // Compiler keeps JSX names; renderer maps className→class
+        expect($result)->toContain("'className'=>\"foo\"");
+    });
+
+    it('can mix intercepted and default attributes on the same element', function () {
+        $compiler = new Compiler(plugins: [makeXIfAttributePlugin()]);
+        $result = $compiler->compile('<div className="foo" x-if={$show} />');
+        expect($result)->toContain("'className'=>\"foo\"");
+        expect($result)->toContain("'__xif__' => (\$show)");
+    });
+
+    it('intercepts prop-punned attributes ({$var} shorthand)', function () {
+        // Plugin that renames 'href' to '__href__'
+        $plugin = new class extends AbstractCompilerPlugin {
+            public function visitAttribute(
+                string $nameText,
+                string $compiledValue,
+                FormatterInterface $formatter,
+            ): ?string {
+                if ($nameText !== 'href') return null;
+                return "'__href__'=>{$compiledValue}";
+            }
+        };
+
+        $compiler = new Compiler(plugins: [$plugin]);
+        $result = $compiler->compile('<a {$href} />');
+        expect($result)->toContain("'__href__'=>\$href");
+    });
+});
+
+// ── AbstractCompilerPlugin no-op base ─────────────────────────────────────────
+
+describe('AbstractCompilerPlugin', function () {
+    it('all methods return null by default', function () {
+        $plugin = new class extends AbstractCompilerPlugin {};
+        $formatter = new \Attitude\PHPX\Compiler\Formatter();
+
+        expect($plugin->visitElement('div', null, null, $formatter))->toBeNull();
+        expect($plugin->visitFragment('[]', $formatter))->toBeNull();
+        expect($plugin->visitAttribute('class', '"foo"', $formatter))->toBeNull();
+    });
+
+    it('a no-op plugin does not alter compiler output', function () {
+        $noOp = new class extends AbstractCompilerPlugin {};
+        $plain = new Compiler();
+        $withPlugin = new Compiler(plugins: [$noOp]);
+
+        $source = '<div className="hello"><span>World</span></div>';
+        expect($withPlugin->compile($source))->toBe($plain->compile($source));
+    });
+});

--- a/tests/language-server/LSPExtensions.spec.php
+++ b/tests/language-server/LSPExtensions.spec.php
@@ -136,6 +136,35 @@ describe('CompletionExtension', function () {
         readOutputMessages($output);
         expect($calls)->toBe(['ext-a', 'ext-b']);
     });
+
+    it('survives a throwing extension and still returns built-in items', function () {
+        $throwing = new class implements CompletionExtension {
+            public function complete(TextDocumentItem $document, int $line, int $character): array {
+                throw new \RuntimeException('extension crash');
+            }
+            public function getCapabilities(): array { return []; }
+        };
+
+        [$server, $output] = createServerWithExtensions(completionExtensions: [$throwing]);
+        initializeExtServer($server, $output);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<d'],
+        ]));
+        rewind($output);
+        ftruncate($output, 0);
+
+        $server->handleMessage(Message::request(1, 'textDocument/completion', [
+            'textDocument' => ['uri' => 'file:///test.phpx'],
+            'position' => ['line' => 0, 'character' => 2],
+        ]));
+
+        $messages = readOutputMessages($output);
+        expect($messages)->toHaveCount(1);
+        // Built-in completions still returned despite extension crash
+        $labels = array_column($messages[0]->result, 'label');
+        expect($labels)->toContain('div');
+    });
 });
 
 // ── HoverExtension ────────────────────────────────────────────────────────────
@@ -232,6 +261,34 @@ describe('HoverExtension', function () {
         expect($messages[0]->result)->not->toBeNull();
         expect($messages[0]->result['contents']['value'])->toContain('className');
     });
+
+    it('survives a throwing extension and falls back to built-in hover', function () {
+        $throwing = new class implements HoverExtension {
+            public function hover(TextDocumentItem $document, int $line, int $character): ?array {
+                throw new \RuntimeException('extension crash');
+            }
+        };
+
+        [$server, $output] = createServerWithExtensions(hoverExtensions: [$throwing]);
+        initializeExtServer($server, $output);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<div className="x">'],
+        ]));
+        rewind($output);
+        ftruncate($output, 0);
+
+        $server->handleMessage(Message::request(1, 'textDocument/hover', [
+            'textDocument' => ['uri' => 'file:///test.phpx'],
+            'position' => ['line' => 0, 'character' => 7],
+        ]));
+
+        $messages = readOutputMessages($output);
+        expect($messages)->toHaveCount(1);
+        // Built-in hover still works despite extension crash
+        expect($messages[0]->result)->not->toBeNull();
+        expect($messages[0]->result['contents']['value'])->toContain('className');
+    });
 });
 
 // ── DiagnosticsExtension ──────────────────────────────────────────────────────
@@ -311,5 +368,27 @@ describe('DiagnosticsExtension', function () {
 
         // Called once for open, once for change
         expect($count)->toBe(2);
+    });
+
+    it('survives a throwing extension and still publishes built-in diagnostics', function () {
+        $throwing = new class implements DiagnosticsExtension {
+            public function diagnose(TextDocumentItem $document): array {
+                throw new \RuntimeException('extension crash');
+            }
+        };
+
+        [$server, $output] = createServerWithExtensions(diagnosticsExtensions: [$throwing]);
+
+        // Open an invalid document — built-in diagnostics should still report the error
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<div>unclosed'],
+        ]));
+
+        $messages = readOutputMessages($output);
+        expect($messages)->toHaveCount(1);
+        expect($messages[0]->method)->toBe('textDocument/publishDiagnostics');
+        // Built-in parse error diagnostics still published despite extension crash
+        expect($messages[0]->params['diagnostics'])->not->toBeEmpty();
+        expect($messages[0]->params['diagnostics'][0]['source'])->toBe('phpx');
     });
 });

--- a/tests/language-server/LSPExtensions.spec.php
+++ b/tests/language-server/LSPExtensions.spec.php
@@ -1,0 +1,315 @@
+<?php declare(strict_types=1);
+
+use Attitude\PHPX\LanguageServer\CompletionExtension;
+use Attitude\PHPX\LanguageServer\DiagnosticsExtension;
+use Attitude\PHPX\LanguageServer\HoverExtension;
+use Attitude\PHPX\LanguageServer\Message;
+use Attitude\PHPX\LanguageServer\Server;
+use Attitude\PHPX\LanguageServer\TextDocumentItem;
+use Attitude\PHPX\LanguageServer\Transport;
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function createServerWithExtensions(
+    array $completionExtensions = [],
+    array $hoverExtensions = [],
+    array $diagnosticsExtensions = [],
+): array {
+    $input = fopen('php://memory', 'r+');
+    $output = fopen('php://memory', 'r+');
+    $transport = new Transport($input, $output);
+    $server = new Server(
+        transport: $transport,
+        completionExtensions: $completionExtensions,
+        hoverExtensions: $hoverExtensions,
+        diagnosticsExtensions: $diagnosticsExtensions,
+    );
+
+    return [$server, $output, $transport];
+}
+
+function initializeExtServer(Server $server, mixed $output): void {
+    $server->handleMessage(Message::request(0, 'initialize', ['capabilities' => []]));
+    rewind($output);
+    ftruncate($output, 0);
+}
+
+// ── CompletionExtension ───────────────────────────────────────────────────────
+
+describe('CompletionExtension', function () {
+    it('merges extension completion items with built-in items', function () {
+        $ext = new class implements CompletionExtension {
+            public function complete(TextDocumentItem $document, int $line, int $character): array {
+                return [['label' => 'x-custom', 'kind' => 14, 'detail' => 'Custom tag']];
+            }
+            public function getCapabilities(): array { return []; }
+        };
+
+        [$server, $output] = createServerWithExtensions(completionExtensions: [$ext]);
+        initializeExtServer($server, $output);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<d'],
+        ]));
+        rewind($output);
+        ftruncate($output, 0);
+
+        $server->handleMessage(Message::request(1, 'textDocument/completion', [
+            'textDocument' => ['uri' => 'file:///test.phpx'],
+            'position' => ['line' => 0, 'character' => 2],
+        ]));
+
+        $messages = readOutputMessages($output);
+        expect($messages)->toHaveCount(1);
+
+        $labels = array_column($messages[0]->result, 'label');
+        expect($labels)->toContain('div');        // built-in
+        expect($labels)->toContain('x-custom');   // extension
+    });
+
+    it('merges trigger characters from extensions into capabilities', function () {
+        $ext = new class implements CompletionExtension {
+            public function complete(TextDocumentItem $document, int $line, int $character): array { return []; }
+            public function getCapabilities(): array { return ['triggerCharacters' => ['x', ':']]; }
+        };
+
+        [$server, $output] = createServerWithExtensions(completionExtensions: [$ext]);
+
+        $server->handleMessage(Message::request(1, 'initialize', ['capabilities' => []]));
+
+        $messages = readOutputMessages($output);
+        expect($messages)->toHaveCount(1);
+
+        $triggers = $messages[0]->result['capabilities']['completionProvider']['triggerCharacters'];
+        expect($triggers)->toContain('<');   // built-in
+        expect($triggers)->toContain('x');  // extension
+        expect($triggers)->toContain(':');  // extension
+    });
+
+    it('deduplicates trigger characters', function () {
+        $ext = new class implements CompletionExtension {
+            public function complete(TextDocumentItem $document, int $line, int $character): array { return []; }
+            public function getCapabilities(): array { return ['triggerCharacters' => ['<', 'x']]; }
+        };
+
+        [$server, $output] = createServerWithExtensions(completionExtensions: [$ext]);
+        $server->handleMessage(Message::request(1, 'initialize', ['capabilities' => []]));
+
+        $messages = readOutputMessages($output);
+        $triggers = $messages[0]->result['capabilities']['completionProvider']['triggerCharacters'];
+
+        // '<' appears in both built-in and extension; must appear only once
+        expect(array_count_values($triggers)['<'])->toBe(1);
+    });
+
+    it('all registered extensions are called', function () {
+        $calls = [];
+
+        $makeExt = function (string $label) use (&$calls): CompletionExtension {
+            return new class($label, $calls) implements CompletionExtension {
+                public function __construct(private string $label, private array &$calls) {}
+                public function complete(TextDocumentItem $document, int $line, int $character): array {
+                    $this->calls[] = $this->label;
+                    return [['label' => $this->label, 'kind' => 14]];
+                }
+                public function getCapabilities(): array { return []; }
+            };
+        };
+
+        [$server, $output] = createServerWithExtensions(completionExtensions: [
+            $makeExt('ext-a'),
+            $makeExt('ext-b'),
+        ]);
+        initializeExtServer($server, $output);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<'],
+        ]));
+        rewind($output);
+        ftruncate($output, 0);
+
+        $server->handleMessage(Message::request(1, 'textDocument/completion', [
+            'textDocument' => ['uri' => 'file:///test.phpx'],
+            'position' => ['line' => 0, 'character' => 1],
+        ]));
+
+        readOutputMessages($output);
+        expect($calls)->toBe(['ext-a', 'ext-b']);
+    });
+});
+
+// ── HoverExtension ────────────────────────────────────────────────────────────
+
+describe('HoverExtension', function () {
+    it('extension hover result takes priority over built-in', function () {
+        $ext = new class implements HoverExtension {
+            public function hover(TextDocumentItem $document, int $line, int $character): ?array {
+                return [
+                    'contents' => ['kind' => 'markdown', 'value' => 'extension hover'],
+                    'range' => ['start' => ['line' => $line, 'character' => 0], 'end' => ['line' => $line, 'character' => 1]],
+                ];
+            }
+        };
+
+        [$server, $output] = createServerWithExtensions(hoverExtensions: [$ext]);
+        initializeExtServer($server, $output);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<div className="x">'],
+        ]));
+        rewind($output);
+        ftruncate($output, 0);
+
+        // Hover on 'className' — built-in would return docs, extension should win
+        $server->handleMessage(Message::request(1, 'textDocument/hover', [
+            'textDocument' => ['uri' => 'file:///test.phpx'],
+            'position' => ['line' => 0, 'character' => 7],
+        ]));
+
+        $messages = readOutputMessages($output);
+        expect($messages)->toHaveCount(1);
+        expect($messages[0]->result['contents']['value'])->toBe('extension hover');
+    });
+
+    it('first extension that returns non-null wins', function () {
+        $calls = [];
+
+        $makeExt = function (bool $handles, string $name) use (&$calls): HoverExtension {
+            return new class($handles, $name, $calls) implements HoverExtension {
+                public function __construct(private bool $handles, private string $name, private array &$calls) {}
+                public function hover(TextDocumentItem $document, int $line, int $character): ?array {
+                    $this->calls[] = $this->name;
+                    if (!$this->handles) return null;
+                    return ['contents' => ['kind' => 'plaintext', 'value' => $this->name]];
+                }
+            };
+        };
+
+        [$server, $output] = createServerWithExtensions(hoverExtensions: [
+            $makeExt(false, 'skip'),
+            $makeExt(true, 'winner'),
+            $makeExt(true, 'never-reached'),
+        ]);
+        initializeExtServer($server, $output);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<div>'],
+        ]));
+        rewind($output);
+        ftruncate($output, 0);
+
+        $server->handleMessage(Message::request(1, 'textDocument/hover', [
+            'textDocument' => ['uri' => 'file:///test.phpx'],
+            'position' => ['line' => 0, 'character' => 1],
+        ]));
+
+        readOutputMessages($output);
+        expect($calls)->toBe(['skip', 'winner']);
+    });
+
+    it('falls back to built-in hover when all extensions return null', function () {
+        $nullExt = new class implements HoverExtension {
+            public function hover(TextDocumentItem $document, int $line, int $character): ?array { return null; }
+        };
+
+        [$server, $output] = createServerWithExtensions(hoverExtensions: [$nullExt]);
+        initializeExtServer($server, $output);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<div className="x">'],
+        ]));
+        rewind($output);
+        ftruncate($output, 0);
+
+        $server->handleMessage(Message::request(1, 'textDocument/hover', [
+            'textDocument' => ['uri' => 'file:///test.phpx'],
+            'position' => ['line' => 0, 'character' => 7],
+        ]));
+
+        $messages = readOutputMessages($output);
+        expect($messages)->toHaveCount(1);
+        // Built-in hover provides className docs
+        expect($messages[0]->result)->not->toBeNull();
+        expect($messages[0]->result['contents']['value'])->toContain('className');
+    });
+});
+
+// ── DiagnosticsExtension ──────────────────────────────────────────────────────
+
+describe('DiagnosticsExtension', function () {
+    it('merges extension diagnostics with built-in diagnostics', function () {
+        $ext = new class implements DiagnosticsExtension {
+            public function diagnose(TextDocumentItem $document): array {
+                return [[
+                    'range' => ['start' => ['line' => 0, 'character' => 0], 'end' => ['line' => 0, 'character' => 1]],
+                    'severity' => 2, // Warning
+                    'source' => 'test-ext',
+                    'message' => 'Extension warning',
+                ]];
+            }
+        };
+
+        [$server, $output] = createServerWithExtensions(diagnosticsExtensions: [$ext]);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<div>Hello</div>'],
+        ]));
+
+        $messages = readOutputMessages($output);
+        expect($messages)->toHaveCount(1);
+
+        $diags = $messages[0]->params['diagnostics'];
+        $sources = array_column($diags, 'source');
+        expect($sources)->toContain('test-ext');
+    });
+
+    it('all registered extensions are called', function () {
+        $calls = [];
+
+        $makeExt = function (string $name) use (&$calls): DiagnosticsExtension {
+            return new class($name, $calls) implements DiagnosticsExtension {
+                public function __construct(private string $name, private array &$calls) {}
+                public function diagnose(TextDocumentItem $document): array {
+                    $this->calls[] = $this->name;
+                    return [];
+                }
+            };
+        };
+
+        [$server, $output] = createServerWithExtensions(diagnosticsExtensions: [
+            $makeExt('ext-a'),
+            $makeExt('ext-b'),
+        ]);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<div>test</div>'],
+        ]));
+
+        expect($calls)->toBe(['ext-a', 'ext-b']);
+    });
+
+    it('extension diagnostics are also published on didChange', function () {
+        $count = 0;
+        $ext = new class($count) implements DiagnosticsExtension {
+            public function __construct(private int &$count) {}
+            public function diagnose(TextDocumentItem $document): array {
+                $this->count++;
+                return [];
+            }
+        };
+
+        [$server, $output] = createServerWithExtensions(diagnosticsExtensions: [$ext]);
+
+        $server->handleMessage(Message::notification('textDocument/didOpen', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'languageId' => 'phpx', 'version' => 1, 'text' => '<div>Hello</div>'],
+        ]));
+
+        $server->handleMessage(Message::notification('textDocument/didChange', [
+            'textDocument' => ['uri' => 'file:///test.phpx', 'version' => 2],
+            'contentChanges' => [['text' => '<span>World</span>']],
+        ]));
+
+        // Called once for open, once for change
+        expect($count)->toBe(2);
+    });
+});

--- a/tests/language-server/Server.spec.php
+++ b/tests/language-server/Server.spec.php
@@ -18,24 +18,6 @@ function createTestServer(): array {
     return [$server, $output, $transport];
 }
 
-/**
- * Reads all messages written to the output stream.
- *
- * @param resource $output
- * @return Message[]
- */
-function readOutputMessages($output): array {
-    rewind($output);
-    $readTransport = new Transport($output, fopen('php://memory', 'r+'));
-    $messages = [];
-
-    while (($msg = $readTransport->read()) !== null) {
-        $messages[] = $msg;
-    }
-
-    return $messages;
-}
-
 describe('Server', function () {
     describe('initialize', function () {
         it('responds to initialize with capabilities', function () {

--- a/tests/language-server/helpers.php
+++ b/tests/language-server/helpers.php
@@ -1,5 +1,26 @@
 <?php declare(strict_types=1);
 
+use Attitude\PHPX\LanguageServer\Message;
+use Attitude\PHPX\LanguageServer\Transport;
+
+/**
+ * Reads all messages written to the output stream.
+ *
+ * @param resource $output
+ * @return Message[]
+ */
+function readOutputMessages($output): array {
+    rewind($output);
+    $readTransport = new Transport($output, fopen('php://memory', 'r+'));
+    $messages = [];
+
+    while (($msg = $readTransport->read()) !== null) {
+        $messages[] = $msg;
+    }
+
+    return $messages;
+}
+
 /**
  * Apply LSP TextEdit[] to source text, producing the resulting document.
  * Edits are sorted in reverse document order so earlier offsets stay valid.


### PR DESCRIPTION
## Summary

Adds plugin/extension points to the Compiler and Language Server — no parser changes.

### Compiler — `CompilerPlugin` visitor interface

- **`CompilerPlugin`** interface with three visitor methods: `visitElement`, `visitFragment`, `visitAttribute`
- **`AbstractCompilerPlugin`** base class with null no-ops so plugins only override what they need
- Plugins are injected via `new Compiler(plugins: [...])` — first non-null return wins, then falls back to the active `FormatterInterface`
- Covers all attribute compilation paths including prop punning (`{$var}` shorthand)
- Whitespace-only `'[]'` values are normalised to `null` before reaching plugins, matching the Formatter's own empty-signal convention

### Language Server — three extension interfaces

| Interface | Behaviour |
|---|---|
| `CompletionExtension` | Items merged with built-in list; `getCapabilities()` trigger chars deduplicated into `initialize` response |
| `HoverExtension` | Tried before built-in provider; first non-null wins |
| `DiagnosticsExtension` | Results merged with built-in diagnostics |

All injected via `Server` constructor: `completionExtensions`, `hoverExtensions`, `diagnosticsExtensions`.

Every extension call is wrapped in `try/catch(\Throwable)` with logging — a crashing extension is skipped and remaining extensions + built-in results proceed normally.

### What this does NOT touch

- **Parser** — no new token types, no AST changes
- **Formatter / Renderer** — unchanged (`FormatterInterface` was already an extension point)
- **Existing public API** — all new parameters have defaults; positional argument order preserved (plugins comes after logger)

## Test plan

- [x] 14 new compiler plugin tests (`CompilerPlugin.spec.php`): element/fragment/attribute interception, plugin ordering, no-op passthrough, prop-punning interception
- [x] 13 new LSP extension tests (`LSPExtensions.spec.php`): completion merging, trigger char dedup, hover priority + fallback, diagnostics merging across didOpen/didChange, error isolation for all three extension types
- [x] Full suite: **472 tests, 0 failures**
- [x] Moved `readOutputMessages` to shared `helpers.php` — no implicit cross-file test dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)