### PR TITLE
fix(parser): Parse keyword-named tags as elements in child position (#32)

### DIFF
--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -201,6 +201,19 @@ final class Parser {
 		];
 	}
 
+	/** True when the cursor is at the start of a child element: `<` + a name-start token (incl. keyword names like <use>). */
+	private function isElementStart(): bool {
+		return $this->tokens->tokenAtCursor()?->text === '<'
+			&& $this->tokens->tokenAtCursorIsNameStart(1) !== null;
+	}
+
+	/** True when the cursor is at the start of a closing tag: `<` `/` + a name-start token. */
+	private function isClosingElementStart(): bool {
+		return $this->tokens->tokenAtCursor()?->text === '<'
+			&& $this->tokens->tokenAtCursor(1)?->text === '/'
+			&& $this->tokens->tokenAtCursorIsNameStart(2) !== null;
+	}
+
 	private function parseTextNode(): array {
 		if ($this->tokens->tokenAtCursorMatches(T_WHITESPACE) && strstr($this->tokens->tokenAtCursor()->text, "\n")) {
 			$this->debugCurrentToken(__FUNCTION__);
@@ -213,8 +226,8 @@ final class Parser {
 			$this->tokens->exist()
 			&& !$this->tokens->tokenAtCursorMatches(TX_FRAGMENT_ELEMENT_OPEN)
 			&& !$this->tokens->tokenAtCursorMatches(TX_FRAGMENT_ELEMENT_CLOSING_SEQUENCE)
-			&& !$this->tokens->tokenAtCursorMatches(TX_ELEMENT_OPENING_OPEN_SEQUENCE)
-			&& !$this->tokens->tokenAtCursorMatches(TX_ELEMENT_CLOSING_OPEN_SEQUENCE)
+			&& !$this->isElementStart()
+			&& !$this->isClosingElementStart()
 			&& !$this->tokens->tokenAtCursorMatches(TX_CURLY_BRACKET_OPEN)
 		) {
 			$this->debugCurrentToken(__FUNCTION__);
@@ -301,7 +314,7 @@ final class Parser {
 		while (
 			$this->tokens->exist()
 			&& !$this->tokens->tokenAtCursorMatches(TX_FRAGMENT_ELEMENT_CLOSING_SEQUENCE)
-			&& !$this->tokens->tokenAtCursorMatches(TX_ELEMENT_CLOSING_OPEN_SEQUENCE)
+			&& !$this->isClosingElementStart()
 		) {
 			$this->debugCurrentToken(__FUNCTION__);
 
@@ -309,10 +322,9 @@ final class Parser {
 				TX_CURLY_BRACKET_OPEN => $this->parseExpressionContainer(),
 				TX_PARENTHESIS_OPEN => $this->parseParentheses(),
 				TX_FRAGMENT_ELEMENT_OPEN => $this->parseFragmentElement(),
-				default => match (!!$this->tokens->tokenAtCursorMatches(TX_ELEMENT_OPENING_OPEN_SEQUENCE)) {
-						true => $this->parseElement(),
-						false => $this->parseTextNode(),
-					},
+				default => $this->isElementStart()
+					? $this->parseElement()
+					: $this->parseTextNode(),
 			};
 		}
 

--- a/tests/parser/Parser.spec.php
+++ b/tests/parser/Parser.spec.php
@@ -120,8 +120,9 @@ describe('Parser accepts PHP keyword names', function () {
             ->toBe('[\'$\', \'div\', null, [[\'$\', \'list\']]]');
     });
 
-    it('still treats < followed by a space as text inside children', function () {
-        expect(phpxCompile('<p>a &lt; b</p>'))->toBe('[\'$\', \'p\', null, [\'a &lt; b\']]');
+    it('still treats a literal < followed by a space as text inside children', function () {
+        // A real `<` token (not the &lt; entity), so the disambiguation actually runs.
+        expect(phpxCompile('<p>a < b</p>'))->toBe('[\'$\', \'p\', null, [\'a < b\']]');
     });
 });
 

--- a/tests/parser/Parser.spec.php
+++ b/tests/parser/Parser.spec.php
@@ -102,6 +102,27 @@ describe('Parser accepts PHP keyword names', function () {
     it('accepts a namespaced attribute name', function () {
         expect(phpxCompile('<use xmlns:xlink="ns" />'))->toBe('[\'$\', \'use\', [\'xmlns:xlink\'=>"ns"]]');
     });
+
+    // Regression for #32: keyword tag names must parse as elements in CHILD
+    // position too, not just at the top level (SVG <use> sprites break otherwise).
+    it('parses a self-closing keyword child as an element', function () {
+        expect(phpxCompile('<div><use href="#x" /></div>'))
+            ->toBe('[\'$\', \'div\', null, [[\'$\', \'use\', [\'href\'=>"#x"]]]]');
+    });
+
+    it('parses a paired keyword child as an element', function () {
+        expect(phpxCompile('<svg><use href="#x"></use></svg>'))
+            ->toBe('[\'$\', \'svg\', null, [[\'$\', \'use\', [\'href\'=>"#x"]]]]');
+    });
+
+    it('parses another keyword child (<list>) as an element', function () {
+        expect(phpxCompile('<div><list></list></div>'))
+            ->toBe('[\'$\', \'div\', null, [[\'$\', \'list\']]]');
+    });
+
+    it('still treats < followed by a space as text inside children', function () {
+        expect(phpxCompile('<p>a &lt; b</p>'))->toBe('[\'$\', \'p\', null, [\'a &lt; b\']]');
+    });
 });
 
 describe('Parser disambiguates < as less-than', function () {


### PR DESCRIPTION
Fixes #32 (filed against the keyword-name support added in #29).

## Problem
Keyword tag names (`<use>`, `<list>`, `<echo>`, …) parse correctly at the top level but were captured as **raw text** in child position:

```php
(new Compiler())->compile('<div><use href="#x" /></div>');
// before: ['$', 'div', null, ['<use href="#x" />']]   ← string!
// after:  ['$', 'div', null, [['$', 'use', ['href'=>"#x"]]]]
```

This broke SVG sprites — `<svg><use href="#icon"/></svg>` rendered the `<use>` as escaped text.

## Cause
Child scanning matched the literal token sequences `['<', T_STRING]` (open) and `['<','/',T_STRING]` (close). PHP tokenizes keyword names as keyword tokens (`T_USE`, `T_LIST`, …), not `T_STRING`, so `<use …>` and `</use>` fell through to `parseTextNode()`.

## Fix
Replaced those sequence checks in `parseElementChildren()` and `parseTextNode()` with name-start-aware helpers (`isElementStart` / `isClosingElementStart`), consistent with the top-level `tokenAtCursorIsNameStart()` disambiguation from #29. `<` followed by a space or digit is still treated as text.

## Tests
Regressions for self-closing and paired keyword children, `<list>`, and the text-with-`<` case. Full suite: **477 passing** on PHP 8.3 / 8.4 / 8.5.

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)