### PR TITLE
fix(parser): disambiguate top-level `<`, remove parse-time PHP warnings, harden asserts

### DIFF
--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -31,7 +31,9 @@ final class Parser {
 				TX_PARENTHESIS_OPEN,
 				TX_SQUARE_BRACKET_OPEN => $this->parseParentheses(),
 				TX_FRAGMENT_ELEMENT_OPEN => $this->parseFragmentElement(),
-				TX_ELEMENT_OPENING_OPEN => $this->parseElement(),
+				TX_ELEMENT_OPENING_OPEN => $this->isElementStart()
+					? $this->parseElement()
+					: ['$$type' => NodeType::EXPRESSION, 'value' => $this->tokens->tokenAtCursorAndForward()],
 				TX_TEMPLATE_LITERAL => $this->parseTemplateLiteral(),
 				default => ['$$type' => NodeType::EXPRESSION, 'value' => $this->tokens->tokenAtCursorAndForward()],
 			};
@@ -61,7 +63,9 @@ final class Parser {
 	private function parseElement(): array {
 		$this->debugCurrentToken(__FUNCTION__);
 		$openingElementStart = $this->tokens->tokenAtCursorAndForward();
-		assert($openingElementStart->id === TX_ELEMENT_OPENING_OPEN);
+		if ($openingElementStart->id !== TX_ELEMENT_OPENING_OPEN) {
+			throw new \LogicException("parseElement() entered without an element opener");
+		}
 
 		$this->debugCurrentToken(__FUNCTION__);
 		$elementName = $this->parseElementName();
@@ -71,11 +75,15 @@ final class Parser {
 		if ($this->tokens->tokenAtCursorMatches(TX_ELEMENT_SELF_CLOSING_SEQUENCE)) {
 			$this->debugCurrentToken(__FUNCTION__);
 			$closingElementSlash = $this->tokens->tokenAtCursorAndForward();
-			assert($closingElementSlash->text === '/');
+			if ($closingElementSlash->text !== '/') {
+				throw new \LogicException("Expected '/' in self-closing sequence");
+			}
 
 			$this->debugCurrentToken(__FUNCTION__);
 			$closingElementEnd = $this->tokens->tokenAtCursorAndForward();
-			assert($closingElementEnd->text === '>');
+			if ($closingElementEnd->text !== '>') {
+				throw new \LogicException("Expected '>' in self-closing sequence");
+			}
 
 			return [
 				'$$type' => NodeType::PHPX_ELEMENT,
@@ -87,7 +95,9 @@ final class Parser {
 		} else if ($this->tokens->tokenAtCursorMatches(TX_ELEMENT_OPENING_CLOSE)) {
 			$this->debugCurrentToken(__FUNCTION__);
 			$openingElementEnd = $this->tokens->tokenAtCursorAndForward();
-			assert($openingElementEnd->id === TX_ELEMENT_OPENING_CLOSE);
+			if ($openingElementEnd->id !== TX_ELEMENT_OPENING_CLOSE) {
+				throw new \LogicException("Expected '>' closing the opening tag");
+			}
 
 			$elementNameText = is_array($elementName)
 				? implode('', array_map(fn(Token $t) => $t->text, $elementName))
@@ -102,11 +112,15 @@ final class Parser {
 
 			$this->debugCurrentToken(__FUNCTION__);
 			$closingElementStart = $this->tokens->tokenAtCursorAndForward();
-			assert($closingElementStart->text === TX_ELEMENT_CLOSING_OPEN_SEQUENCE[0]);
+			if ($closingElementStart->text !== TX_ELEMENT_CLOSING_OPEN_SEQUENCE[0]) {
+				throw new \LogicException("Expected '<' opening the closing tag");
+			}
 
 			$this->debugCurrentToken(__FUNCTION__);
 			$closingElementSlash = $this->tokens->tokenAtCursorAndForward();
-			assert($closingElementSlash->text === TX_ELEMENT_CLOSING_OPEN_SEQUENCE[1]);
+			if ($closingElementSlash->text !== TX_ELEMENT_CLOSING_OPEN_SEQUENCE[1]) {
+				throw new \LogicException("Expected '/' in the closing tag");
+			}
 
 			$this->debugCurrentToken(__FUNCTION__);
 			$closingElementName = $this->parseElementName();
@@ -178,7 +192,9 @@ final class Parser {
 
 	private function parseExpressionContainer(): array {
 		$this->debugCurrentToken(__FUNCTION__);
-		assert($this->tokens->tokenAtCursorMatches(TX_CURLY_BRACKET_OPEN));
+		if ($this->tokens->tokenAtCursorMatches(TX_CURLY_BRACKET_OPEN) === null) {
+			throw new \LogicException("parseExpressionContainer() entered without '{'");
+		}
 
 		$expression = $this->parseParentheses();
 
@@ -187,7 +203,7 @@ final class Parser {
 				return $expression['children'][0];
 			}
 
-			if ($expression['children'][0]->id === T_COMMENT) {
+			if ($expression['children'][0] instanceof Token && $expression['children'][0]->id === T_COMMENT) {
 				return [
 					'$$type' => NodeType::PHPX_COMMENT,
 					'comment' => $expression['children'][0],
@@ -298,7 +314,9 @@ final class Parser {
 		}
 
 		$closer = $this->tokens->tokenAtCursorAndForward();
-		assert($closer->id === TX_TEMPLATE_LITERAL);
+		if ($closer->id !== TX_TEMPLATE_LITERAL) {
+			throw new \LogicException("Expected template literal closer");
+		}
 
 		return [
 			'$$type' => NodeType::TEMPLATE_LITERAL,
@@ -382,6 +400,9 @@ final class Parser {
 
 		if ($this->tokens->tokenAtCursorMatches('=')) {
 			$assignment = $this->tokens->tokenAtCursorAndForward();
+			if (!$this->tokens->exist()) {
+				throw new \ParseError($this->unexpectedTokenMessage('attribute "value" or {expression}'));
+			}
 			$value = match ($this->tokens->tokenAtCursor()->id) {
 				T_CURLY_OPEN,
 				TX_CURLY_BRACKET_OPEN => $this->parseParentheses(),
@@ -429,7 +450,7 @@ final class Parser {
 				TX_PARENTHESIS_OPEN,
 				TX_SQUARE_BRACKET_OPEN => $this->parseParentheses(),
 				TX_FRAGMENT_ELEMENT_OPEN => $this->parseFragmentElement(),
-				TX_ELEMENT_OPENING_OPEN => $this->tokens->tokenAtCursorIsNameStart(1)
+				TX_ELEMENT_OPENING_OPEN => $this->isElementStart()
 				? $this->parseElement()
 				: $this->tokens->tokenAtCursorAndForward(),
 				TX_TEMPLATE_LITERAL => $this->parseTemplateLiteral(),
@@ -464,6 +485,10 @@ final class Parser {
 	}
 
 	private function debugCurrentToken(string $method): void {
+		if ($this->logger === null) {
+			return;
+		}
+
 		$token = $this->tokens->tokenAtCursor();
 
 		if ($token === null) {

--- a/src/parser/TokensList.php
+++ b/src/parser/TokensList.php
@@ -18,7 +18,7 @@ final class TokensList implements \JsonSerializable, \Iterator {
 	private function tokenAtCursorMatchesSequence(array $sequence): Token|null {
 		foreach ($sequence as $i => $text) {
 			if (!is_string($text) && !is_int($text)) {
-				throw new \InvalidArgumentException("Sequence element must be string or int, got " . gettype($text));
+				throw new \InvalidArgumentException("Sequence element must be string or int, got " . get_debug_type($text));
 			}
 
 			if ($this->exist()) {
@@ -97,7 +97,7 @@ final class TokensList implements \JsonSerializable, \Iterator {
 				return null;
 			}
 		} else {
-			throw new \InvalidArgumentException("Invalid value type " . gettype($value));
+			throw new \InvalidArgumentException("Invalid value type " . get_debug_type($value));
 		}
 	}
 

--- a/src/parser/TokensList.php
+++ b/src/parser/TokensList.php
@@ -9,13 +9,17 @@ final class TokensList implements \JsonSerializable, \Iterator {
 
 	public function __construct(private array $tokens) {
 		foreach ($this->tokens as $token) {
-			assert($token instanceof Token);
+			if (!($token instanceof Token)) {
+				throw new \TypeError('TokensList expects an array of Token instances.');
+			}
 		}
 	}
 
 	private function tokenAtCursorMatchesSequence(array $sequence): Token|null {
 		foreach ($sequence as $i => $text) {
-			assert(is_string($text) || is_int($text));
+			if (!is_string($text) && !is_int($text)) {
+				throw new \InvalidArgumentException("Sequence element must be string or int, got " . gettype($text));
+			}
 
 			if ($this->exist()) {
 				if (is_string($text)) {

--- a/tests/compiler/Compiler.spec.php
+++ b/tests/compiler/Compiler.spec.php
@@ -1030,10 +1030,11 @@ describe('unexpected end of input', function () {
       ->toThrow(\ParseError::class, "expected closing ']'");
   });
 
-  it('throws ParseError for truncated opening tag with no element name', function () {
+  it('treats a lone < as a less-than expression, not a truncated tag', function () {
+    // A `<` not followed by a name-start is disambiguated as less-than (same as
+    // inside parentheses), so it passes through instead of erroring.
     $compiler = newCompiler(parser: newParser());
-    expect(fn() => $compiler->compile('<'))
-      ->toThrow(\ParseError::class, "expected element name");
+    expect($compiler->compile('<'))->toBe('<');
   });
 
   it('throws ParseError for truncated opening tag missing closing bracket', function () {

--- a/tests/language-server/EditingSession.spec.php
+++ b/tests/language-server/EditingSession.spec.php
@@ -136,8 +136,8 @@ describe('Editing Sessions', function () {
             expect(count($diags))->toBeGreaterThanOrEqual(4);
 
             // First: empty file - may or may not error depending on implementation
-            // Second: "<" should have error (malformed)
-            expect($diags[1]->params['diagnostics'])->not->toBe([]);
+            // Second: "<" alone is a valid less-than operator (not a truncated tag) - no error
+            expect($diags[1]->params['diagnostics'])->toBe([]);
 
             // Third: "<div>" unclosed should have error
             expect($diags[2]->params['diagnostics'])->not->toBe([]);

--- a/tests/parser/Parser.spec.php
+++ b/tests/parser/Parser.spec.php
@@ -148,6 +148,62 @@ describe('Parser disambiguates < as less-than', function () {
     });
 });
 
+describe('Parser disambiguates top-level < as less-than', function () {
+    // A top-level `<` not followed by a name-start is a comparison operator, not an
+    // element opener — it must pass through unchanged, just like inside parentheses.
+    $cases = [
+        '$ok = $a < $b;' => '$ok = $a < $b;',
+        'return $a < $b ? 1 : 2;' => 'return $a < $b ? 1 : 2;',
+        'fn() < 5' => 'fn() < 5',
+        '$x < $y > $z' => '$x < $y > $z',
+        'if ($a < $b) {}' => 'if ($a < $b) {}',
+    ];
+
+    foreach ($cases as $source => $expected) {
+        it("compiles {$source} unchanged", function () use ($source, $expected) {
+            expect(phpxCompile($source))->toBe($expected);
+        });
+    }
+
+    it('still parses a real element at the top level', function () {
+        expect(phpxCompile('<div>hi</div>'))->toBe('[\'$\', \'div\', null, [\'hi\']]');
+    });
+});
+
+describe('Parser error-level cleanliness', function () {
+    /** Run $fn under E_ALL, returning the PHP warning/notice messages it emits. */
+    function phpxCaptureWarnings(callable $fn): array
+    {
+        $previous = error_reporting(E_ALL);
+        $warnings = [];
+        set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = $errstr;
+            return true;
+        });
+        try {
+            $fn();
+        } catch (\ParseError $e) {
+            // expected for some inputs; we only care about the warnings collected
+        } finally {
+            restore_error_handler();
+            error_reporting($previous);
+        }
+        return $warnings;
+    }
+
+    it('throws ParseError for a truncated attribute at EOF with no PHP warning', function () {
+        $warnings = phpxCaptureWarnings(fn() => phpxParse('<div a='));
+        expect($warnings)->toBe([]);
+        expect(fn() => phpxParse('<div a='))
+            ->toThrow(\ParseError::class, 'expected attribute "value" or {expression}');
+    });
+
+    it('parses an element inside an expression container with no PHP warning', function () {
+        $warnings = phpxCaptureWarnings(fn() => phpxParse('<div>{<span/>}</div>'));
+        expect($warnings)->toBe([]);
+    });
+});
+
 describe('Parser error handling', function () {
     $invalid = [
         'mismatched closing tag' => ['<div></span>', 'closing tag to match'],


### PR DESCRIPTION
## Summary

Verified parser fixes against `main`. All are surgical; the full Pest suite passes (513 tests).

### A. [HIGH] Top-level `<` is now disambiguated as less-than
`parse()` routed **every** `<` token to `parseElement()`, so a statement-scope comparison threw a parse error while the same expression inside `(...)` parsed fine.

```php
$ok = $a < $b;   // before: ParseError "Unexpected token ' ', expected element name"
                 // after:  compiles unchanged
```

All three dispatch sites now share the existing `isElementStart()` predicate (`<` + a name-start token). At the top level and in parentheses, a `<` that is not an element opener is consumed as a plain token — exactly what the parentheses else-branch already did. `parseElementChildren()` already used the helper and is unchanged. Fragment-open (`<>`) and closing-sequence dispatch already behaved identically across the sites.

Consequence: a lone `<` (or `<` not followed by a name-start) is a less-than operator that passes through, matching the parentheses behaviour. Two existing tests that asserted the old "truncated tag" error are updated:
- `tests/compiler/Compiler.spec.php` — `compile('<')` now returns `'<'`.
- `tests/language-server/EditingSession.spec.php` — typing a lone `<` no longer raises a diagnostic.

Repro now covered: `$ok = $a < $b;`, `return $a < $b ? 1 : 2;`, `fn() < 5`, `$x < $y > $z`, `if ($a < $b) {}`, and real elements still parse.

### B. [MEDIUM] Null deref warning on truncated input
`<div a=` at EOF reached `match ($this->tokens->tokenAtCursor()->id)` after consuming `=`, emitting an `E_WARNING` before the `ParseError`. A null check now throws the existing-style `ParseError` ("Unexpected end of input, expected attribute \"value\" or {expression}") directly, with no warning.

### C. [MEDIUM] Array deref warning on valid input
`<div>{<span/>}</div>` emitted "Attempt to read property id on array" (parse still succeeded). The single-child comment check is now guarded with `instanceof Token`.

### D. [LOW] Residual `assert()` calls converted to explicit exceptions
Internal-invariant `assert()`s in `Parser.php` (8) and `TokensList.php` (2) are converted to `\LogicException` / `\TypeError` / `\InvalidArgumentException`, following the "Harden the PHPX core" (#29) pattern, so dev and prod behave identically.

### E. [PERF] Skip debug work when no logger
`debugCurrentToken()` returns early when `$this->logger === null`, avoiding ~55k unnecessary `tokenAtCursor()` calls per large file.

### F. [PERF] O(n²) bare-comment path — SKIPPED
Confirmed the quadratic: each bare `//`/`#` comment in markup calls `TokensList::replaceTokenAtCursor()`, whose `array_splice` rebuilds the **entire** token array on every call (verified position-independent: ~25ms for 2000 splices whether at the start or end of a 5000-element array). Bench: 100 comments 2ms → 800 comments 16ms, with the splice loop accounting for roughly half.

Every clean O(total) fix requires either rewriting `TokensList`'s core read path to a gap buffer (shared by parser, compiler and LSP, called ~55k times/file — too broad for a surgical change and correctness-risky) or a fragile fast-path in `parseTextNode` that entangles the trailing-whitespace trim logic. Since F is explicitly lower priority than the A–C correctness fixes, and hundreds of bare comments **directly in markup text** (not inside `{}`, which are never expanded) is a rare shape, F is skipped. E remains as the low-risk perf win.

## Tests
Regression tests added to `tests/parser/Parser.spec.php`: the less-than cases, and error-level cleanliness for B and C (run under `E_ALL`, warnings captured via `set_error_handler`).

```
Tests:    513 passed (11684 assertions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)