### PR TITLE
feat(parser): SyntaxRecognizer plugin system — pluggable syntax recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,57 @@ $compiler->compile('<div>a{/* note */}b</div>');
 
 With no visitors, the output is byte-for-byte identical to the default compiler.
 
+#### Extending the parser with syntax recognizers
+
+The third extension point is the *recognition* layer. `SyntaxRecognizer` lets you teach the parser new token patterns — JSX is conceptually just one of the options, like a Babel parser plugin. A recognizer implements:
+
+- **`claims(TokensList $tokens): bool`** — return true when the tokens at the cursor start your construct. It MUST NOT move the cursor.
+- **`parse(TokensList $tokens, Parser $parser): array`** — parse the construct into a node and advance the cursor past it. It may call `$parser->parseNext()` to recurse into standard parsing for nested constructs.
+
+The node you return carries `'$$type' => NodeType|string`. A **string** `$$type` is a custom node kind: it travels through `NodeTraverser` like any node, so a `NodeVisitor` must **lower** it to a built-in `NodeType` node before compilation. A custom node that reaches the compiler unlowered throws.
+
+Register recognizers on the parser and the lowering visitor on the compiler:
+
+```php
+use Attitude\PHPX\Compiler\{Compiler, AbstractNodeVisitor};
+use Attitude\PHPX\Parser\{NodeType, Parser, SyntaxRecognizer, Token, TokensList};
+
+$macro = new class implements SyntaxRecognizer {
+    public function claims(TokensList $tokens): bool {
+        return $tokens->tokenAtCursorMatches(['%', '%']) !== null;
+    }
+    public function parse(TokensList $tokens, Parser $parser): array {
+        $tokens->tokenAtCursorAndForward(); // %
+        $tokens->tokenAtCursorAndForward(); // %
+        $inner = [];
+        while ($tokens->exist() && $tokens->tokenAtCursorMatches(['%', '%']) === null) {
+            $inner[] = $tokens->tokenAtCursorAndForward();
+        }
+        $tokens->tokenAtCursorAndForward(); // %
+        $tokens->tokenAtCursorAndForward(); // %
+        return ['$$type' => 'Macro', 'tokens' => $inner];
+    }
+};
+
+$lowerMacro = new class extends AbstractNodeVisitor {
+    public function enterNode(array $node): array|int|null {
+        return ($node['$$type'] ?? null) === 'Macro'
+            ? ['$$type' => NodeType::EXPRESSION, 'value' => new Token(T_STRING, 'time()', 1, 0)]
+            : null;
+    }
+};
+
+$compiler = new Compiler(parser: new Parser(recognizers: [$macro]), visitors: [$lowerMacro]);
+$compiler->compile('%%now%%'); // time()
+```
+
+Two limitations in this release:
+
+- Recognizers are consulted only at **node boundaries** (top level, and inside `(...)`/`[...]`/`{...}` and element children). They do not interrupt a JSX text run — place custom syntax right after `{...}` or an element, not mid-text.
+- **Attributes are not yet pluggable** — recognizers do not run inside a tag's attribute list.
+
+With no recognizers, the parser output is byte-for-byte identical to the default parser.
+
 ---
 
 ### Renderer

--- a/src/compiler/Compiler.php
+++ b/src/compiler/Compiler.php
@@ -37,6 +37,11 @@ final class Compiler {
 		$this->visitors = $visitors;
 	}
 
+	private static function unknownNodeTypeError(mixed $type): \RuntimeException {
+		$name = $type instanceof NodeType ? $type->value : (is_string($type) ? $type : get_debug_type($type));
+		return new \RuntimeException("Unhandled node type '{$name}'. Custom nodes produced by a SyntaxRecognizer must be lowered to built-in NodeType nodes by a NodeVisitor before compilation.");
+	}
+
 	public function compile(string $source): string {
 		$this->source = $source;
 		$this->tokens = new TokensList(Token::tokenize($source));
@@ -56,7 +61,7 @@ final class Compiler {
 				NodeType::PHPX_ELEMENT => $this->compilePHPXElement($node),
 				NodeType::PHPX_FRAGMENT => $this->compilePHPXFragmentElement($node),
 				NodeType::PHPX_ATTRIBUTE => $this->compilePHPXAttribute($node),
-				default => throw new \RuntimeException("Unknown node type: {$node['$$type']}"),
+				default => throw self::unknownNodeTypeError($node['$$type']),
 			};
 		}
 		return $this->compiled;
@@ -93,7 +98,7 @@ final class Compiler {
 				NodeType::PHPX_TEXT => $this->compilePHPXText($child, $index, $childrenCount),
 				NodeType::PHPX_EXPRESSION_CONTAINER => $this->compilePHPXExpressionContainer($child) . ', ',
 				NodeType::PHPX_COMMENT => $this->compilePHPXComment($child),
-				default => throw new \RuntimeException("Unknown child type: {$child['$$type']->value}"),
+				default => throw self::unknownNodeTypeError($child['$$type']),
 			};
 		}
 
@@ -271,7 +276,7 @@ final class Compiler {
 					NodeType::BLOCK => $this->compileBlock($child),
 					NodeType::PHPX_ELEMENT => $this->compilePHPXElement($child),
 					NodeType::PHPX_FRAGMENT => $this->compilePHPXFragmentElement($child),
-					default => throw new \RuntimeException("Unknown child type: {$child['$$type']}"),
+					default => throw self::unknownNodeTypeError($child['$$type']),
 				};
 			}
 		}
@@ -301,7 +306,7 @@ final class Compiler {
 						NodeType::PHPX_FRAGMENT => $this->compilePHPXFragmentElement($value),
 						NodeType::PHPX_EXPRESSION_CONTAINER => $this->compilePHPXExpressionContainer($value),
 						NodeType::TEMPLATE_LITERAL => $this->compileTemplateLiteral($value),
-						default => throw new \RuntimeException("Unknown child type: {$value['$$type']}"),
+						default => throw self::unknownNodeTypeError($value['$$type']),
 					},
 			}, $children))
 			. ($replaceClosing !== null ? $replaceClosing : $closing->text);

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -9,9 +9,19 @@ use Psr\Log\LoggerInterface;
 final class Parser {
 	private TokensList $tokens;
 	private array $ast;
+	/** @var SyntaxRecognizer[] */
+	private array $recognizers;
 	public function __construct(
 		private ?LoggerInterface $logger = null,
+		array $recognizers = [],
 	) {
+		foreach ($recognizers as $recognizer) {
+			if (!$recognizer instanceof SyntaxRecognizer) {
+				$given = get_debug_type($recognizer);
+				throw new \InvalidArgumentException("Parser \$recognizers must all be SyntaxRecognizer instances, {$given} given.");
+			}
+		}
+		$this->recognizers = $recognizers;
 	}
 
 	public function parse(TokensList $tokens): array {
@@ -24,24 +34,57 @@ final class Parser {
 		while ($this->tokens->exist()) {
 			$this->debugCurrentToken(__FUNCTION__);
 
-			$this->ast[] = match ($this->tokens->tokenAtCursor()->id) {
-				T_CURLY_OPEN,
-				T_DOLLAR_OPEN_CURLY_BRACES,
-				TX_CURLY_BRACKET_OPEN,
-				TX_PARENTHESIS_OPEN,
-				TX_SQUARE_BRACKET_OPEN => $this->parseParentheses(),
-				TX_FRAGMENT_ELEMENT_OPEN => $this->parseFragmentElement(),
-				TX_ELEMENT_OPENING_OPEN => $this->isElementStart()
-					? $this->parseElement()
-					: ['$$type' => NodeType::EXPRESSION, 'value' => $this->tokens->tokenAtCursorAndForward()],
-				TX_TEMPLATE_LITERAL => $this->parseTemplateLiteral(),
-				default => ['$$type' => NodeType::EXPRESSION, 'value' => $this->tokens->tokenAtCursorAndForward()],
-			};
+			$this->ast[] = $this->parseNext();
 		}
 
 		$this->logger?->debug('AST', $this->ast);
 
 		return $this->ast;
+	}
+
+	/**
+	 * Parse exactly one node at the cursor: first any registered SyntaxRecognizer,
+	 * then the built-in dispatch. Exposed so a recognizer can recurse into standard
+	 * parsing for nested constructs — only callable while a parse is in progress.
+	 */
+	public function parseNext(): array {
+		return $this->parseRecognized() ?? match ($this->tokens->tokenAtCursor()->id) {
+			T_CURLY_OPEN,
+			T_DOLLAR_OPEN_CURLY_BRACES,
+			TX_CURLY_BRACKET_OPEN,
+			TX_PARENTHESIS_OPEN,
+			TX_SQUARE_BRACKET_OPEN => $this->parseParentheses(),
+			TX_FRAGMENT_ELEMENT_OPEN => $this->parseFragmentElement(),
+			TX_ELEMENT_OPENING_OPEN => $this->isElementStart()
+				? $this->parseElement()
+				: ['$$type' => NodeType::EXPRESSION, 'value' => $this->tokens->tokenAtCursorAndForward()],
+			TX_TEMPLATE_LITERAL => $this->parseTemplateLiteral(),
+			default => ['$$type' => NodeType::EXPRESSION, 'value' => $this->tokens->tokenAtCursorAndForward()],
+		};
+	}
+
+	/**
+	 * Consult registered recognizers at the cursor. For the first that claims the
+	 * tokens, parse and return its node; return null when none claims.
+	 */
+	private function parseRecognized(): ?array {
+		foreach ($this->recognizers as $recognizer) {
+			if (!$recognizer->claims($this->tokens)) {
+				continue;
+			}
+
+			$before = $this->tokens->index();
+			$node = $recognizer->parse($this->tokens, $this);
+
+			if ($this->tokens->index() === $before) {
+				$class = $recognizer::class;
+				throw new \LogicException("SyntaxRecognizer {$class} claimed the tokens but did not advance the cursor.");
+			}
+
+			return $node;
+		}
+
+		return null;
 	}
 
 	private function parseFragmentElement(): array {
@@ -336,6 +379,12 @@ final class Parser {
 		) {
 			$this->debugCurrentToken(__FUNCTION__);
 
+			$recognized = $this->parseRecognized();
+			if ($recognized !== null) {
+				$children[] = $recognized;
+				continue;
+			}
+
 			$children[] = match ($this->tokens->tokenAtCursor()->id) {
 				TX_CURLY_BRACKET_OPEN => $this->parseExpressionContainer(),
 				TX_PARENTHESIS_OPEN => $this->parseParentheses(),
@@ -442,6 +491,12 @@ final class Parser {
 
 		while ($this->tokens->exist() && !$this->tokens->tokenAtCursorMatches($closerId)) {
 			$this->debugCurrentToken(__FUNCTION__);
+
+			$recognized = $this->parseRecognized();
+			if ($recognized !== null) {
+				$children[] = $recognized;
+				continue;
+			}
 
 			$children[] = match ($this->tokens->tokenAtCursor()->id) {
 				T_CURLY_OPEN,

--- a/src/parser/SyntaxRecognizer.php
+++ b/src/parser/SyntaxRecognizer.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Attitude\PHPX\Parser;
+
+/**
+ * Pluggable syntax recognizer: the parser consults recognizers at every
+ * node boundary before falling back to its built-in dispatch, so a construct
+ * like JSX becomes just one of the options.
+ */
+interface SyntaxRecognizer {
+	/**
+	 * Return true when the tokens at the cursor start a construct this recognizer parses.
+	 * MUST NOT move the cursor.
+	 */
+	public function claims(TokensList $tokens): bool;
+
+	/**
+	 * Parse the claimed construct into a node. MUST advance the cursor past the construct.
+	 *
+	 * The returned node carries '$$type' => NodeType|string. A string '$$type' is a custom
+	 * node kind: it travels through NodeTraverser like any node, but must be lowered to a
+	 * built-in NodeType node by a NodeVisitor before compilation.
+	 */
+	public function parse(TokensList $tokens, Parser $parser): array;
+}

--- a/src/parser/index.php
+++ b/src/parser/index.php
@@ -4,4 +4,5 @@ require_once __DIR__ . '/constants.php';
 require_once __DIR__ . '/NodeType.php';
 require_once __DIR__ . '/TokensList.php';
 require_once __DIR__ . '/Token.php';
+require_once __DIR__ . '/SyntaxRecognizer.php';
 require_once __DIR__ . '/Parser.php';

--- a/tests/parser/SyntaxRecognizer.spec.php
+++ b/tests/parser/SyntaxRecognizer.spec.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+use Attitude\PHPX\Compiler\AbstractNodeVisitor;
+use Attitude\PHPX\Compiler\Compiler;
+use Attitude\PHPX\Parser\NodeType;
+use Attitude\PHPX\Parser\Parser;
+use Attitude\PHPX\Parser\SyntaxRecognizer;
+use Attitude\PHPX\Parser\Token;
+use Attitude\PHPX\Parser\TokensList;
+
+/**
+ * Demo recognizer for `%% ... %%`: claims the `%%` opener and consumes up to the
+ * matching `%%` closer, producing a custom (string) node type.
+ */
+final class MacroRecognizer implements SyntaxRecognizer {
+	public function claims(TokensList $tokens): bool {
+		return $tokens->tokenAtCursorMatches(['%', '%']) !== null;
+	}
+
+	public function parse(TokensList $tokens, Parser $parser): array {
+		$tokens->tokenAtCursorAndForward(); // %
+		$tokens->tokenAtCursorAndForward(); // %
+
+		$inner = [];
+		while ($tokens->exist() && $tokens->tokenAtCursorMatches(['%', '%']) === null) {
+			$inner[] = $tokens->tokenAtCursorAndForward();
+		}
+
+		$tokens->tokenAtCursorAndForward(); // %
+		$tokens->tokenAtCursorAndForward(); // %
+
+		return ['$$type' => 'TestMacro', 'tokens' => $inner];
+	}
+}
+
+/** Lowers the custom `TestMacro` node to a built-in EXPRESSION emitting `time()`. */
+final class MacroLowering extends AbstractNodeVisitor {
+	public function enterNode(array $node): array|int|null {
+		if (($node['$$type'] ?? null) !== 'TestMacro') {
+			return null;
+		}
+		return ['$$type' => NodeType::EXPRESSION, 'value' => new Token(T_STRING, 'time()', 1, 0)];
+	}
+}
+
+/** Demo recognizer for `@`: claims the marker, then recurses into standard parsing. */
+final class AtRecognizer implements SyntaxRecognizer {
+	public function claims(TokensList $tokens): bool {
+		return $tokens->tokenAtCursorMatches('@') !== null;
+	}
+
+	public function parse(TokensList $tokens, Parser $parser): array {
+		$marker = $tokens->tokenAtCursorAndForward(); // @
+		return ['$$type' => 'AtWrapped', 'marker' => $marker, 'inner' => $parser->parseNext()];
+	}
+}
+
+/** Broken recognizer: claims `~` but never advances the cursor. */
+final class NonAdvancingRecognizer implements SyntaxRecognizer {
+	public function claims(TokensList $tokens): bool {
+		return $tokens->tokenAtCursorMatches('~') !== null;
+	}
+
+	public function parse(TokensList $tokens, Parser $parser): array {
+		return ['$$type' => 'Never'];
+	}
+}
+
+/** Parse PHPX source with the given recognizers. */
+function recognizedAstOf(string $source, array $recognizers): array
+{
+	return (new Parser(recognizers: $recognizers))->parse(new TokensList(Token::tokenize($source)));
+}
+
+describe('SyntaxRecognizer', function () {
+	it('recognizes a custom construct at the top level', function () {
+		$ast = recognizedAstOf('%%time%%', [new MacroRecognizer()]);
+
+		expect($ast)->toHaveCount(1);
+		expect($ast[0]['$$type'])->toBe('TestMacro');
+	});
+
+	it('compiles a custom construct end-to-end once a visitor lowers it', function () {
+		$compiler = new Compiler(
+			parser: new Parser(recognizers: [new MacroRecognizer()]),
+			visitors: [new MacroLowering()],
+		);
+
+		expect($compiler->compile('%%time%%'))->toBe('time()');
+	});
+
+	it('recognizes a custom construct inside a block', function () {
+		$ast = recognizedAstOf('[%%time%%]', [new MacroRecognizer()]);
+
+		expect($ast[0]['$$type'])->toBe(NodeType::BLOCK);
+		expect($ast[0]['children'][0]['$$type'])->toBe('TestMacro');
+	});
+
+	it('recognizes a custom construct at a JSX child boundary', function () {
+		$ast = recognizedAstOf('<div>{$a}%%x%%</div>', [new MacroRecognizer()]);
+
+		$macros = array_filter(
+			$ast[0]['children'],
+			fn($child) => is_array($child) && ($child['$$type'] ?? null) === 'TestMacro',
+		);
+
+		expect($macros)->toHaveCount(1);
+	});
+
+	it('lets a recognizer recurse into standard parsing via parseNext()', function () {
+		$ast = recognizedAstOf('@<div>x</div>', [new AtRecognizer()]);
+
+		expect($ast[0]['$$type'])->toBe('AtWrapped');
+		expect($ast[0]['inner']['$$type'])->toBe(NodeType::PHPX_ELEMENT);
+	});
+
+	it('throws when an unlowered custom node reaches the Compiler', function () {
+		$compiler = new Compiler(parser: new Parser(recognizers: [new MacroRecognizer()]));
+
+		expect(fn() => $compiler->compile('%%time%%'))
+			->toThrow(\RuntimeException::class, 'must be lowered');
+	});
+
+	it('throws when a recognizer claims but does not advance the cursor', function () {
+		expect(fn() => recognizedAstOf('~foo', [new NonAdvancingRecognizer()]))
+			->toThrow(\LogicException::class, NonAdvancingRecognizer::class);
+	});
+
+	it('rejects non-SyntaxRecognizer entries at construction', function () {
+		expect(fn() => new Parser(recognizers: ['not a recognizer']))
+			->toThrow(\InvalidArgumentException::class, 'SyntaxRecognizer');
+	});
+
+	it('produces identical output with no recognizers', function () {
+		$source = '<div id="x">hi</div>';
+		$plain = (new Compiler())->compile($source);
+		$empty = (new Compiler(parser: new Parser(recognizers: [])))->compile($source);
+
+		expect($empty)->toBe($plain);
+	});
+});


### PR DESCRIPTION
Completes the extensibility story started in #30 with the third seam: pluggable **syntax recognition**. #30 made the AST transformable; this makes the *vocabulary* extensible — the parser's dispatch is no longer a closed set of hard-coded patterns, so JSX becomes conceptually one syntax plugin among possible others (the Babel parser-plugin half to #30's transform half).

## Three orthogonal extension points

| Seam | Controls | Interface |
|---|---|---|
| Output shape | array tuples vs `pragma(...)` | `FormatterInterface` (existing) |
| Tree transformation | inspect / rewrite / remove nodes | `NodeVisitor` (#30) |
| Syntax recognition | which token patterns produce nodes | `SyntaxRecognizer` (new) |

## API

```php
interface SyntaxRecognizer {
    public function claims(TokensList $tokens): bool;                 // MUST NOT move the cursor
    public function parse(TokensList $tokens, Parser $parser): array; // MUST advance the cursor
}
```

- `Parser` gains a `recognizers` constructor argument (after `logger`, positional contract preserved), validated the same way `Compiler` validates `visitors`.
- Recognizers are consulted at every node boundary — top level, inside `(...)`/`[...]`/`{...}`, and element children — *before* the built-in dispatch, so they can also override built-ins. Attribute lists and JSX text runs stay closed realms for now.
- `Parser::parseNext()` is now public so a recognizer can recurse into standard parsing for nested constructs.
- **Lowering convention (Babel-style):** a recognizer returns a node with a custom string `$$type`; a paired `NodeVisitor` lowers it to built-in `NodeType` nodes before codegen. An unlowered custom node reaching the `Compiler` throws with an actionable message (this also fixes the pre-existing enum-interpolation fatal in the `default` arms).
- A recognizer that claims but does not advance the cursor throws `LogicException` instead of hanging the parse loop.

**Non-breaking:** with no recognizers, parser output is byte-for-byte identical (all 566 pre-existing tests pass unchanged; regression test included).

## Tests

9 new tests in `tests/parser/SyntaxRecognizer.spec.php`: top-level recognition, end-to-end compile through recognizer + lowering visitor, recognition inside blocks and at JSX child boundaries, `parseNext()` recursion, unlowered-node error, non-advancing-recognizer guard, constructor validation, zero-recognizers identity. Full suite: **575 passing** (11810 assertions).

Docs: new "Extending the parser with syntax recognizers" README section with a worked example and the two current limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
